### PR TITLE
Added support for mapping array properties

### DIFF
--- a/src/Helpers/TypeHelper.php
+++ b/src/Helpers/TypeHelper.php
@@ -47,6 +47,17 @@ class TypeHelper
 
     public static function isCustomClass(string $type): bool
     {
-        return ! self::isScalarType($type) && ! self::isBuiltinClass($type);
+        return ! self::isScalarType($type) && ! self::isBuiltinClass($type) && ! self::isArray($type);
+    }
+
+    public static function isArray(string $type, ?string &$innertype = null): bool
+    {
+        if (strlen($type) <= 2 || substr_compare($type, '[]', -2, 2) !== 0) {
+            return false;
+        }
+
+        $innertype = substr($type, 0, -2);
+
+        return true;
     }
 }

--- a/src/Middleware/NamespaceResolver.php
+++ b/src/Middleware/NamespaceResolver.php
@@ -20,7 +20,7 @@ class NamespaceResolver extends AbstractMiddleware
         /** @var Property $property */
         foreach ($propertyMap as &$property) {
             $type = $property->getType();
-            if (TypeHelper::isArray($type, $innerType)) {
+            if ($isArray = TypeHelper::isArray($type, $innerType)) {
                 $type = $innerType;
             }
 
@@ -30,13 +30,16 @@ class NamespaceResolver extends AbstractMiddleware
 
             $matches = array_filter(
                 $imports,
-                static function (string $import) use ($property) {
-                    return $property->getType() === substr($import, -1 * strlen($property->getType()));
+                static function (string $import) use ($type) {
+                    return $type === substr($import, -1 * strlen($type));
                 }
             );
 
             if (count($matches) > 0) {
                 $type = array_shift($matches);
+                if ($isArray) {
+                    $type .= '[]';
+                }
                 $propertyMap->addProperty($property->asBuilder()->setType($type)->build());
                 continue;
             }

--- a/src/Middleware/NamespaceResolver.php
+++ b/src/Middleware/NamespaceResolver.php
@@ -19,7 +19,12 @@ class NamespaceResolver extends AbstractMiddleware
 
         /** @var Property $property */
         foreach ($propertyMap as &$property) {
-            if (! TypeHelper::isCustomClass($property->getType())) {
+            $type = $property->getType();
+            if (TypeHelper::isArray($type, $innerType)) {
+                $type = $innerType;
+            }
+
+            if (! TypeHelper::isCustomClass($type)) {
                 continue;
             }
 

--- a/tests/Implementation/ComplexObject.php
+++ b/tests/Implementation/ComplexObject.php
@@ -10,6 +10,8 @@ class ComplexObject
 {
     /** @var SimpleObject */
     private $child;
+    /** @var SimpleObject[] */
+    private $children;
     /** @var User */
     private $user;
 
@@ -21,6 +23,16 @@ class ComplexObject
     public function setChild(SimpleObject $child): void
     {
         $this->child = $child;
+    }
+
+    public function getChildren(): array
+    {
+        return $this->children;
+    }
+
+    public function setChildren(array $children): void
+    {
+        $this->children = $children;
     }
 
     public function getUser(): User

--- a/tests/Unit/Helpers/TypeHelperTest.php
+++ b/tests/Unit/Helpers/TypeHelperTest.php
@@ -43,6 +43,22 @@ class TypeHelperTest extends TestCase
         self::assertEquals($expected, TypeHelper::cast($value, $castTo));
     }
 
+    /**
+     * @covers       \JsonMapper\Helpers\TypeHelper
+     * @dataProvider arrayTypesDataProvider
+     *
+     * @param mixed $value
+     * @param bool $expectedResult
+     * @param string|null $expectedInnerType
+     */
+    public function testArraysAreSeenAsArray(string $value, bool $expectedResult, ?string $expectedInnerType): void
+    {
+        $result = TypeHelper::isArray($value, $innerType);
+        
+        self::assertEquals($expectedResult, $result);
+        self::assertEquals($expectedInnerType, $innerType);
+    }
+
     public function scalarTypesDataProvider(): array
     {
         return [
@@ -75,6 +91,15 @@ class TypeHelperTest extends TestCase
             'cast to int' => ['42', 'int', 42],
             'cast to float' => ['34.567', 'float', 34.567],
             'cast to  unsupported type' => ['34.567', 'bigint', '34.567'],
+        ];
+    }
+
+    public function arrayTypesDataProvider(): array
+    {
+        return [
+            'class array' => ['DateTime[]', true, 'DateTime'],
+            'int array' => ['int[]', true, 'int'],
+            'bad array' => ['[]', false, null],
         ];
     }
 }

--- a/tests/Unit/Middleware/NamespaceResolverTest.php
+++ b/tests/Unit/Middleware/NamespaceResolverTest.php
@@ -85,4 +85,50 @@ class NamespaceResolverTest extends TestCase
         self::assertTrue($propertyMap->hasProperty('name'));
         self::assertEquals('string', $propertyMap->getProperty('name')->getType());
     }
+
+    /**
+     * @covers \JsonMapper\Middleware\NamespaceResolver
+     */
+    public function testItResolvesNamespacesForImportedNamespaceWithArray(): void
+    {
+        $middleware = new NamespaceResolver();
+        $object = new ComplexObject();
+        $property = PropertyBuilder::new()
+            ->setName('user')
+            ->setType('User[]')
+            ->setVisibility(Visibility::PRIVATE())
+            ->setIsNullable(false)
+            ->build();
+        $propertyMap = new PropertyMap();
+        $propertyMap->addProperty($property);
+        $jsonMapper = $this->createMock(JsonMapperInterface::class);
+
+        $middleware->handle(new \stdClass(), new ObjectWrapper($object), $propertyMap, $jsonMapper);
+
+        self::assertTrue($propertyMap->hasProperty('user'));
+        self::assertEquals(User::class . '[]', $propertyMap->getProperty('user')->getType());
+    }
+
+    /**
+     * @covers \JsonMapper\Middleware\NamespaceResolver
+     */
+    public function testItResolvesNamespacesWithinSameNamespaceWithArray(): void
+    {
+        $middleware = new NamespaceResolver();
+        $object = new ComplexObject();
+        $property = PropertyBuilder::new()
+            ->setName('child')
+            ->setType('SimpleObject[]')
+            ->setVisibility(Visibility::PRIVATE())
+            ->setIsNullable(false)
+            ->build();
+        $propertyMap = new PropertyMap();
+        $propertyMap->addProperty($property);
+        $jsonMapper = $this->createMock(JsonMapperInterface::class);
+
+        $middleware->handle(new \stdClass(), new ObjectWrapper($object), $propertyMap, $jsonMapper);
+
+        self::assertTrue($propertyMap->hasProperty('child'));
+        self::assertEquals(SimpleObject::class . '[]', $propertyMap->getProperty('child')->getType());
+    }
 }


### PR DESCRIPTION
This PR adds support for properties with annotations like these:

```php
/**
 * @var int[] $param
 */
```

```php
/**
 * @var ClassName[] $param
 */
```