### PR TITLE
Fix DocBlock type parsing

### DIFF
--- a/src/Handler/PropertyMapper.php
+++ b/src/Handler/PropertyMapper.php
@@ -40,6 +40,10 @@ class PropertyMapper
             $propertyInfo = $propertyMap->getProperty($key);
             $type = $propertyInfo->getType();
 
+			if ($propertyInfo->isNullable() && is_null($value)) {
+				continue;
+			}
+
             if ($propertyInfo->isArray()) {
                 $value = array_map(function ($value) use ($mapper, $type) {
                     return $this->mapPropertyValue($mapper, $type, $value);

--- a/src/Middleware/DocBlockAnnotations.php
+++ b/src/Middleware/DocBlockAnnotations.php
@@ -86,7 +86,7 @@ class DocBlockAnnotations extends AbstractMiddleware
             $type = substr($type, 0, -2);
         }
 
-        $nullable = stripos('|' . $type . '|', '|null|') !== false;
+        $nullable = stripos($docBlock, '|null') !== false;
 
         return new PropertyType($type, $nullable, $isArray);
     }

--- a/src/Middleware/DocBlockAnnotations.php
+++ b/src/Middleware/DocBlockAnnotations.php
@@ -15,7 +15,7 @@ use Psr\SimpleCache\CacheInterface;
 
 class DocBlockAnnotations extends AbstractMiddleware
 {
-    private const DOC_BLOCK_REGEX = '/@(?P<name>[A-Za-z_-]+)(?:[ \t]+(?P<value>.*?))?[ \t]*\r?$/m';
+    private const DOC_BLOCK_REGEX = '/@(?P<name>[A-Za-z_-]+)[ \t]+(?P<value>[\w\[\]\\\\]*).*$/m';
 
     /** @var CacheInterface */
     private $cache;

--- a/tests/Implementation/ComplexObject.php
+++ b/tests/Implementation/ComplexObject.php
@@ -8,7 +8,7 @@ use JsonMapper\Tests\Implementation\Models\User;
 
 class ComplexObject
 {
-    /** @var SimpleObject */
+    /** @var SimpleObject|null */
     private $child;
     /** @var SimpleObject[] */
     private $children;
@@ -17,7 +17,7 @@ class ComplexObject
     /** @var mixed  */
     public $mixedParam;
 
-    public function getChild(): SimpleObject
+    public function getChild(): ?SimpleObject
     {
         return $this->child;
     }

--- a/tests/Integration/JsonMapperTest.php
+++ b/tests/Integration/JsonMapperTest.php
@@ -165,6 +165,20 @@ class JsonMapperTest extends TestCase
         self::assertSame(__METHOD__, $object->getChild()->getName());
     }
 
+    public function testItCanMapAnObjectWithANullClassAttribute(): void
+    {
+        // Arrange
+        $mapper = (new JsonMapperFactory())->bestFit();
+        $object = new ComplexObject();
+        $json = (object) ['child' => null];
+
+        // Act
+        $mapper->mapObject($json, $object);
+
+        // Assert
+        self::assertNull($object->getChild());
+    }
+
     public function testItCanMapAnObjectWithACustomClassAttributeFromAnotherNamespace(): void
     {
         // Arrange

--- a/tests/Unit/Handler/PropertyMapperTest.php
+++ b/tests/Unit/Handler/PropertyMapperTest.php
@@ -228,4 +228,52 @@ class PropertyMapperTest extends TestCase
 
         self::assertEquals(new UserWithConstructor(1234, 'John Doe'), $object->user);
     }
+
+    /**
+     * @covers \JsonMapper\Handler\PropertyMapper
+     */
+    public function testPublicNullableCustomClassNullIsNotSet(): void
+    {
+        $property = PropertyBuilder::new()
+            ->setName('child')
+            ->setType(SimpleObject::class)
+            ->setIsNullable(true)
+            ->setVisibility(Visibility::PRIVATE())
+            ->setIsArray(false)
+            ->build();
+        $propertyMap = new PropertyMap();
+        $propertyMap->addProperty($property);
+        $jsonMapper = $this->createMock(JsonMapperInterface::class);
+        $json = (object) ['child' => null];
+        $object = new ComplexObject();
+        $wrapped = new ObjectWrapper($object);
+        $propertyMapper = new PropertyMapper();
+
+        $propertyMapper->__invoke($json, $wrapped, $propertyMap, $jsonMapper);
+
+        self::assertNull($object->getChild());
+    }
+
+    /**
+     * @covers \JsonMapper\Handler\PropertyMapper
+     */
+    public function testPublicNotNullableCustomClassThrowsException(): void
+    {
+        $property = PropertyBuilder::new()
+            ->setName('child')
+            ->setType(SimpleObject::class)
+            ->setIsNullable(false)
+            ->setVisibility(Visibility::PRIVATE())
+            ->setIsArray(false)
+            ->build();
+        $propertyMap = new PropertyMap();
+        $propertyMap->addProperty($property);
+        $jsonMapper = $this->createMock(JsonMapperInterface::class);
+        $json = (object) ['child' => null];
+        $object = new ComplexObject();
+        $wrapped = new ObjectWrapper($object);
+        $propertyMapper = new PropertyMapper();
+		self::expectException(\Throwable::class);
+        $propertyMapper->__invoke($json, $wrapped, $propertyMap, $jsonMapper);
+    }
 }

--- a/tests/Unit/Middleware/DocBlockAnnotationsTest.php
+++ b/tests/Unit/Middleware/DocBlockAnnotationsTest.php
@@ -134,7 +134,7 @@ class DocBlockAnnotationsTest extends TestCase
     {
         $middleware = new DocBlockAnnotations(new NullCache());
         $object = new class {
-            /** @var nullableNumber|null This is a nullable number*/
+            /** @var NullableNumber|null This is a nullable number*/
             public $nullableNumber;
         };
 
@@ -143,7 +143,7 @@ class DocBlockAnnotationsTest extends TestCase
 
         $middleware->handle(new \stdClass(), new ObjectWrapper($object), $propertyMap, $jsonMapper);
 
-        self::assertEquals('nullableNumber', $propertyMap->getProperty('nullableNumber')->getType());
+        self::assertEquals('NullableNumber', $propertyMap->getProperty('nullableNumber')->getType());
     }
 
 }

--- a/tests/Unit/Middleware/DocBlockAnnotationsTest.php
+++ b/tests/Unit/Middleware/DocBlockAnnotationsTest.php
@@ -33,7 +33,7 @@ class DocBlockAnnotationsTest extends TestCase
         self::assertTrue($propertyMap->hasProperty('child'));
         self::assertEquals('SimpleObject', $propertyMap->getProperty('child')->getType());
         self::assertEquals(Visibility::PRIVATE(), $propertyMap->getProperty('child')->getVisibility());
-        self::assertFalse($propertyMap->getProperty('child')->isNullable());
+        self::assertTrue($propertyMap->getProperty('child')->isNullable());
         self::assertFalse($propertyMap->getProperty('child')->isArray());
         self::assertTrue($propertyMap->hasProperty('children'));
         self::assertEquals('SimpleObject', $propertyMap->getProperty('children')->getType());

--- a/tests/Unit/Middleware/DocBlockAnnotationsTest.php
+++ b/tests/Unit/Middleware/DocBlockAnnotationsTest.php
@@ -144,6 +144,7 @@ class DocBlockAnnotationsTest extends TestCase
         $middleware->handle(new \stdClass(), new ObjectWrapper($object), $propertyMap, $jsonMapper);
 
         self::assertEquals('NullableNumber', $propertyMap->getProperty('nullableNumber')->getType());
+        self::assertTrue($propertyMap->getProperty('nullableNumber')->isNullable());
     }
 
 }

--- a/tests/Unit/Middleware/DocBlockAnnotationsTest.php
+++ b/tests/Unit/Middleware/DocBlockAnnotationsTest.php
@@ -126,4 +126,24 @@ class DocBlockAnnotationsTest extends TestCase
 
         $middleware->handle(new \stdClass(), $objectWrapper, $propertyMap, $jsonMapper);
     }
+
+    /**
+     * @covers \JsonMapper\Middleware\DocBlockAnnotations
+     */
+    public function testTypeIsCorrectlyCalculatedForNullableVars(): void
+    {
+        $middleware = new DocBlockAnnotations(new NullCache());
+        $object = new class {
+            /** @var nullableNumber|null This is a nullable number*/
+            public $nullableNumber;
+        };
+
+        $propertyMap = new PropertyMap();
+        $jsonMapper = $this->createMock(JsonMapperInterface::class);
+
+        $middleware->handle(new \stdClass(), new ObjectWrapper($object), $propertyMap, $jsonMapper);
+
+        self::assertEquals('nullableNumber', $propertyMap->getProperty('nullableNumber')->getType());
+    }
+
 }


### PR DESCRIPTION
This PR should fix #57.
The regex used for calculating the type of variable was not considering some special characters such as spaces or `|` that would act as delimiters between the name and the `null` property or the description.

Here is [the regex explanation at regex101 with some examples](https://regex101.com/r/uxvyGS/2).

I propose [this new regex](https://regex101.com/r/nbRKEG/1/) that would cover these special cases. I've checked all tests pass so it should cover all possible cases.