### PR TITLE
Add phpbenchmarks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "phpcbf": "phpcbf src tests",
         "phpstan": "phpstan analyse",
         "unit-tests": "phpunit --testsuite unit --testdox --coverage-clover=build/logs/clover-unit-tests.xml",
-        "integration-tests": "phpunit --testsuite integration --testdox --coverage-clover=build/logs/clover-integration-tests.xml"
+        "integration-tests": "phpunit --testsuite integration --testdox --coverage-clover=build/logs/clover-integration-tests.xml",
+        "benchmarks": "phpbench run tests/benchmark --report=default"
     },
     "suggest": {
         "json-mapper/laravel-package": "Use JsonMapper directly with Laravel",

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,0 +1,3 @@
+{
+  "runner.bootstrap": "vendor/autoload.php"
+}

--- a/tests/Implementation/Api/ChuckNorris/Php71/Joke.php
+++ b/tests/Implementation/Api/ChuckNorris/Php71/Joke.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonMapper\Tests\Implementation\Api\ChuckNorris\Php71;
+
+class Joke
+{
+    /** @var string[] */
+    public $categories;
+    /** @var \DateTimeImmutable */
+    public $created_at;
+    /** @var string */
+    public $icon_url;
+    /** @var string */
+    public $id;
+    /** @var \DateTimeImmutable */
+    public $updated_at;
+    /** @var string */
+    public $url;
+    /** @var string */
+    public $value;
+}

--- a/tests/Implementation/Api/ChuckNorris/Php71/SearchResponse.php
+++ b/tests/Implementation/Api/ChuckNorris/Php71/SearchResponse.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonMapper\Tests\Implementation\Api\ChuckNorris\Php71;
+
+class SearchResponse
+{
+    /** @var int */
+    public $total;
+    /** @var Joke[] */
+    public $result;
+}

--- a/tests/benchmark/JsonMapperBench.php
+++ b/tests/benchmark/JsonMapperBench.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonMapper\Tests\benchmark;
+
+use JsonMapper\JsonMapperFactory;
+use JsonMapper\JsonMapperInterface;
+use JsonMapper\Tests\Implementation\Api\ChuckNorris\Php71\SearchResponse;
+
+class JsonMapperBench
+{
+    /** @var JsonMapperInterface */
+    private $mapper;
+    /** @var string*/
+    private $content;
+
+    public function __construct()
+    {
+        $this->mapper = (new JsonMapperFactory())->bestFit();
+        $this->content = file_get_contents(__DIR__ . '/../resources/chucknorris/kick.json');
+    }
+
+    /**
+     * @Revs(100)
+     * @Iterations(5)
+     */
+    public function benchMapSimpleObject(): void
+    {
+        $this->mapper->mapObjectFromString(
+            '{"id":131,"type":"general","setup":"How do you organize a space party?","punchline":"You planet."}',
+            new Joke()
+        );
+    }
+
+    /**
+     * @Revs(100)
+     * @Iterations(5)
+     */
+    public function benchMapComplexObject(): void
+    {
+        $this->mapper->mapObjectFromString($this->content, new SearchResponse());
+    }
+}

--- a/tests/resources/chucknorris/kick.json
+++ b/tests/resources/chucknorris/kick.json
@@ -1,0 +1,6573 @@
+{
+  "total": 821,
+  "result": [
+    {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "iyigyr-fqi-cxllf6qnpag",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/iyigyr-fqi-cxllf6qnpag",
+    "value": "Chuck Norris keeps his friends close and his enemies closer. Close enough to drop them with one round house kick to the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Z4Kr-UukTl2XutloFvRZNA",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/Z4Kr-UukTl2XutloFvRZNA",
+    "value": "Chuck Norris can execute a roundhouse kick in a telephone booth!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "zV2fzxDvRMyEdgSk2jTVKg",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/zV2fzxDvRMyEdgSk2jTVKg",
+    "value": "Chuck Norris' sperm can kick your ass"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "6HX-zoSlRFuKLDrPGl83cw",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/6HX-zoSlRFuKLDrPGl83cw",
+    "value": "Chuck Norris rounddhouse kicks kittens and baby's for fun."
+  }, {
+    "categories": ["dev"],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "zdj0bfkjsmup6pkb2rpmbw",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/zdj0bfkjsmup6pkb2rpmbw",
+    "value": "Chuck Norris is the only human being to display the Heisenberg uncertainty principle - you can never know both exactly where and how quickly he will roundhouse-kick you in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "MlP1e4owRr-PyO9kIqlAfg",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/MlP1e4owRr-PyO9kIqlAfg",
+    "value": "Chuck Norris stopped at a stop sign, it turned green. Someone once asked Chuck Norris for advice, he's know dead. Chuck Norris saw a man tell his gf \"you take my breathe away\" he kicked him in the chest and said \"wrong\" Even Chuck Norris shadows is scared of him. Someone thought prank calling Chuck Norris from across the world would keep him save, he kicked him through the phone. When Chuck Norris dies he doesn't go to heaven or hell, he goes to Olympus"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "go6nGny4S72B9YAVBq1f2g",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/go6nGny4S72B9YAVBq1f2g",
+    "value": "Chuck Norris once whent to pizzahut. He ordered an eggroll with some swiss cheese. A rotten cow corpse.A dead president.And a large box with Hellfire missiles. Pizza hut served it on a big tuna fish pizza. Chuck Norris Roundhousekicked the whole place to oblivion making everyone inside suffer terrible pain for eternity. Chuck Norris did not order any pizza."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "9vqrfnk0qhoainqtrwgg4w",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/9vqrfnk0qhoainqtrwgg4w",
+    "value": "He who lives by the sword, dies by the sword. He who lives by Chuck Norris, dies by the roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "tjq8lv6lqi-uoo5cxiu2oa",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/tjq8lv6lqi-uoo5cxiu2oa",
+    "value": "Chuck Norris can be unlocked on the hardest level of Tekken. But only Chuck Norris is skilled enough to unlock himself. Then he roundhouse kicks the Playstation back to Japan."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "LNqCW_FmQ5ubonXnop02kQ",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/LNqCW_FmQ5ubonXnop02kQ",
+    "value": "The only thing you can beat Chuck Norris at is the number of times you've had your face kicked in."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "h2y1uucftfsrzhhussrbiq",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/h2y1uucftfsrzhhussrbiq",
+    "value": "The Bermuda Triangle used to be the Bermuda Square, until Chuck Norris Roundhouse kicked one of the corners off."
+  }, {
+    "categories": ["career"],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "cwguxfhptcuagndjdt1hya",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/cwguxfhptcuagndjdt1hya",
+    "value": "In the beginning there was nothing...then Chuck Norris Roundhouse kicked that nothing in the face and said \"Get a job\". That is the story of the universe."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ldq6_b4mslm489drbfmd9q",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/ldq6_b4mslm489drbfmd9q",
+    "value": "Since 1940, the year Chuck Norris was born, roundhouse kick related deaths have increased 13,000 percent."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ovpkkf3lr2ar6wix6nef7q",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/ovpkkf3lr2ar6wix6nef7q",
+    "value": "Chuck Norris doesnt shave; he kicks himself in the face. The only thing that can cut Chuck Norris is Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "yvrhbpauspegla4pf7dxna",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/yvrhbpauspegla4pf7dxna",
+    "value": "Chuck Norris is the only person who can simultaneously hold and fire FIVE Uzis: One in each hand, one in each foot -- and the 5th one he roundhouse-kicks into the air, so that it sprays bullets."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "kl5ppkvirn2xg2xhjbd8og",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/kl5ppkvirn2xg2xhjbd8og",
+    "value": "How many roundhouse kicks does it take to get to the center of a tootsie pop? Just one. From Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "nj2g0xbnrf6xzb-vfohzbq",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/nj2g0xbnrf6xzb-vfohzbq",
+    "value": "Little Miss Muffet sat on her tuffet, until Chuck Norris roundhouse kicked her into a glacier."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "uw_3pnxjqdijbnum28u17g",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/uw_3pnxjqdijbnum28u17g",
+    "value": "Human cloning is outlawed because of Chuck Norris, because then it would be possible for a Chuck Norris roundhouse kick to meet another Chuck Norris roundhouse kick. Physicists theorize that this contact would end the universe."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "eyybzzcqse6ls_xwlbyscg",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/eyybzzcqse6ls_xwlbyscg",
+    "value": "Chuck Norris invented a language that incorporates karate and roundhouse kicks. So next time Chuck Norris is kicking your ass, don?t be offended or hurt, he may be just trying to tell you he likes your hat."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "i6hnatlnsxwgzj_ruqkubg",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/i6hnatlnsxwgzj_ruqkubg",
+    "value": "A man once claimed Chuck Norris kicked his ass twice, but it was promptly dismissed as false - no one could survive it the first time."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "_3fic7lhtggb9sccwquysa",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/_3fic7lhtggb9sccwquysa",
+    "value": "Chuck Norris roundhouse kicks don't really kill people. They wipe out their entire existence from the space-time continuum."
+  }, {
+    "categories": ["fashion"],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "0wdewlp2tz-mt_upesvrjw",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/0wdewlp2tz-mt_upesvrjw",
+    "value": "Chuck Norris does not follow fashion trends, they follow him. But then he turns around and kicks their ass. Nobody follows Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "mbWbKoWNRc24HNXQIt9ubA",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/mbWbKoWNRc24HNXQIt9ubA",
+    "value": "Chuck Norris chooses not to compete in an Ironman because of the swim, every time he starts kicking and swinging his arms, people die!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "obr8yor_qv6rdrnnvcgayw",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/obr8yor_qv6rdrnnvcgayw",
+    "value": "Every time Chuck Norris smiles, someone dies. Unless he smiles while he?s roundhouse kicking someone in the face. Then two people die."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:18.823766",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "6awjrbewqzeorpsnnsdlag",
+    "updated_at": "2020-01-05 13:42:18.823766",
+    "url": "https://api.chucknorris.io/jokes/6awjrbewqzeorpsnnsdlag",
+    "value": "Chuck Norris? roundhouse kick is so powerful, it can be seen from outer space by the naked eye."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "kGjO8ja6TY6n6CaIAlBl-w",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/kGjO8ja6TY6n6CaIAlBl-w",
+    "value": "You don't really see a light at the end of the tunnel you see Chuck Norris roundhouse kick your face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "y5yiitk0tbgz3tosanyeaw",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/y5yiitk0tbgz3tosanyeaw",
+    "value": "According to Einstein's theory of relativity, Chuck Norris can actually roundhouse kick you yesterday."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "u4xgukrisucgbi8lhx_wkw",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/u4xgukrisucgbi8lhx_wkw",
+    "value": "It is said that looking into Chuck Norris' eyes will reveal your future. Unfortunately, everybody's future is always the same: death by a roundhouse-kick to the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gkdmoby6rg6obe8u_n2gaq",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/gkdmoby6rg6obe8u_n2gaq",
+    "value": "Every time someone uses the word \"intense\", Chuck Norris always replies \"you know what else is intense?\" followed by a roundhouse kick to the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ufgjcp0_qrugwggnmqhvdq",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/ufgjcp0_qrugwggnmqhvdq",
+    "value": "Chuck Norris does not kick ass and take names. In fact, Chuck Norris kicks ass and assigns the corpse a number. It is currently recorded to be in the billions."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "zGQp6B1wSrmNrE5ijXwVHA",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/zGQp6B1wSrmNrE5ijXwVHA",
+    "value": "Chuck Norris was born when the roundhouse kicks were two minutes apart."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "boa13y2fqk-knkj8yuy19w",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/boa13y2fqk-knkj8yuy19w",
+    "value": "Little known medical fact: Chuck Norris invented the Caesarean section when he roundhouse-kicked his way out of his monther's womb."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "99i2pfwpr0sscfyjctywsw",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/99i2pfwpr0sscfyjctywsw",
+    "value": "Since 1940, the year Chuck Norris was born, roundhouse-kick related deaths have increased 13,000 percent."
+  }, {
+    "categories": ["dev"],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "mbxkx1y8qgwbu5ld3qen4w",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/mbxkx1y8qgwbu5ld3qen4w",
+    "value": "Chuck Norris compresses his files by doing a flying round house kick to the hard drive."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ot1bq3lrt_23uwmakbba3g",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/ot1bq3lrt_23uwmakbba3g",
+    "value": "When Chuck Norris plays Oregon Trail, his family does not die from cholera or dysentery, but rather, roundhouse kicks to the face. He also requires no wagon, since he carries the oxen, axels, and buffalo meat on his back. He always makes it to Oregon before you."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "p1bscolyrlg-cviwpkmjba",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/p1bscolyrlg-cviwpkmjba",
+    "value": "Pluto is actually an orbiting group of British soldiers from the American Revolution who entered space after the Chuck gave them a roundhouse kick to the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "6l9zm-aqtuq1wkxidhwa4w",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/6l9zm-aqtuq1wkxidhwa4w",
+    "value": "Kryptonite has been found to contain trace elements of Chuck Norris roundhouse kicks to the face. This is why it is so deadly to Superman."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "0wsFII4QTfmw8cG6iqs86A",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/0wsFII4QTfmw8cG6iqs86A",
+    "value": "i kicked Chuck Norris' ass the other day, then i rode the magic rainbow bus to fairy land and had tea with the easter bunny."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "4n76tu_jtcuutl1xl5k9sg",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/4n76tu_jtcuutl1xl5k9sg",
+    "value": "Two wrongs don't make a right. Unless you're Chuck Norris. Then two wrongs make a roundhouse kick to the face."
+  }, {
+    "categories": ["dev"],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "hlsa0rurqwyqanmszx0miq",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/hlsa0rurqwyqanmszx0miq",
+    "value": "Scientists have estimated that the energy given off during the Big Bang is roughly equal to 1CNRhK (Chuck Norris Roundhouse Kick)."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "1i7ddr75taqda_jqolw0ra",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/1i7ddr75taqda_jqolw0ra",
+    "value": "If you ask Chuck Norris what time it is, he always answers \"Two seconds till\". After you ask \"Two seconds to what?\", he roundhouse kicks you in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "dyrg0pvytxw0zy8lfdp5ag",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/dyrg0pvytxw0zy8lfdp5ag",
+    "value": "Someone once tried to tell Chuck Norris that roundhouse kicks aren't the best way to kick someone. This has been recorded by historians as the worst mistake anyone has ever made."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "S8JeYXgPTCyxHlskLbC6qg",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/S8JeYXgPTCyxHlskLbC6qg",
+    "value": "Chuck Norris never actually gets hit by punches and kicks, he actually is performing a fighting style where he smashes the limbs of his foes with his face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "aoyarv4rtuw5m846bh_ing",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/aoyarv4rtuw5m846bh_ing",
+    "value": "Chuck Norris has never been in a fight, ever. Do you call one roundhouse kick to the face a fight?"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "igoujmmmqt2yc8jzb1kkww",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/igoujmmmqt2yc8jzb1kkww",
+    "value": "A Chuck Norris-delivered Roundhouse Kick is the preferred method of execution in 16 states."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "_gczr0ctrjaia-asoqxbrq",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/_gczr0ctrjaia-asoqxbrq",
+    "value": "If Chuck Norris were a calendar, every month would be named Chucktober, and every day he'd kick your ass."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "e0qejf_zqjumu4rpg1huua",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/e0qejf_zqjumu4rpg1huua",
+    "value": "Fear is not the only emotion Chuck Norris can smell. He can also detect hope, as in \"I hope I don't get a roundhouse kick from Chuck Norris.\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ocpw1ex6qfoole7gvia3ew",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/ocpw1ex6qfoole7gvia3ew",
+    "value": "Fool me once, shame on you. Fool Chuck Norris once and he will roundhouse kick you in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "pn8lrabrtbmfops1amqqpg",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/pn8lrabrtbmfops1amqqpg",
+    "value": "Chuck Norris once round-house kicked a salesman. Over the phone."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "yec826sksvow5e5kxgdl3w",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/yec826sksvow5e5kxgdl3w",
+    "value": "It is better to give than to receive. This is especially true of a Chuck Norris roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "D1HKI2A-R0uEPA5j3rIJfw",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/D1HKI2A-R0uEPA5j3rIJfw",
+    "value": "Captain Planet once told Chuck Norris that he had control over all the elements - earth, water, wind and fire. Chuck Norris then drowned him in fire and blew him six feet under, thereby utilizing all four elements to move the good captain asunder. (It should be noted here that Chuck Norris, for the first time ever, deviated from using his signature roundhouse kick.)"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "garmcdAbTTGanAYd_VtAhw",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/garmcdAbTTGanAYd_VtAhw",
+    "value": "The name 'Chuck Norris' rolls off the tongue and kicks you in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "bctbwqxesukmhrjuumupaw",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/bctbwqxesukmhrjuumupaw",
+    "value": "If you ask Chuck Norris what time it is, he always says, \"Two seconds 'til.\" After you ask, \"Two seconds 'til what?\" he roundhouse kicks you in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "z8XIJSrOTpqNGkuiFVCEbA",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/z8XIJSrOTpqNGkuiFVCEbA",
+    "value": "Chuck Norris can hammer an nail into the wall with a roundhouse kick"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.104863",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "wr247cnmthuzu-jz57lxiq",
+    "updated_at": "2020-01-05 13:42:19.104863",
+    "url": "https://api.chucknorris.io/jokes/wr247cnmthuzu-jz57lxiq",
+    "value": "CNN was originally created as the \"Chuck Norris Network\" to update Americans with on-the-spot ass kicking in real-time."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "dmppfaxjqnkfubpqzgcmxq",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/dmppfaxjqnkfubpqzgcmxq",
+    "value": "Using his trademark roundhouse kick, Chuck Norris once made a fieldgoal in RJ Stadium in Tampa Bay from the 50 yard line of Qualcomm stadium in San Diego."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "znkm6ggrrf22cnlizfby1a",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/znkm6ggrrf22cnlizfby1a",
+    "value": "Chuck Norris can kick through all 6 degrees of separation, hitting anyone, anywhere, in the face, at any time."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "_npdfx5oroyfs0v9rxuglw",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/_npdfx5oroyfs0v9rxuglw",
+    "value": "When you're Chuck Norris, anything + anything is equal to 1. One roundhouse kick to the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "KDNst_DLT321gRz8bBN1YQ",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/KDNst_DLT321gRz8bBN1YQ",
+    "value": "Chuck Norris can recycle anything he wants,including his roundhouse kicks."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "kb43vo_4rtoladsdlnnpsq",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/kb43vo_4rtoladsdlnnpsq",
+    "value": "Some kids play Kick the can. Chuck Norris played Kick the keg."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ropmm-mhrtotnxq95rsdrg",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/ropmm-mhrtotnxq95rsdrg",
+    "value": "On the set of Walker Texas Ranger Chuck Norris brought a dying lamb back to life by nuzzling it with his beard. As the onlookers gathered, the lamb sprang to life. Chuck Norris then roundhouse kicked it, killing it instantly. This was just to prove that the good Chuck givet"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gvm13ovts-wc-he9kpkobq",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/gvm13ovts-wc-he9kpkobq",
+    "value": "Chuck Norris is the only person in the world that can actually email a roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "5FNPTo_vSXqv51umsP0Mig",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/5FNPTo_vSXqv51umsP0Mig",
+    "value": "A fight broke out at a bar between a gangster who had a gun, a farmer who had a bat and Chuck Norris. Chuck Norris proceeded to win the fight with only a 3 inch piece of dental floss, a stick of chapstick, and an unlimited amount of Round House Kicks."
+  }, {
+    "categories": ["science"],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "zfgekm2usfyfra7m5x0wta",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/zfgekm2usfyfra7m5x0wta",
+    "value": "If tapped, a Chuck Norris roundhouse kick could power the country of Australia for 44 minutes."
+  }, {
+    "categories": ["science"],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "u-xwyw6rq0-dxrq1rioogg",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/u-xwyw6rq0-dxrq1rioogg",
+    "value": "Chuck Norris once roundhouse kicked someone so hard that his foot broke the speed of light, went back in time, and killed Amelia Earhart while she was flying over the Pacific Ocean."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "O1psmCrLT8-HC7uDeGnLyg",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/O1psmCrLT8-HC7uDeGnLyg",
+    "value": "This little piggy went to the market,this little piggy stayed home,this little piggy went we we we all the way home because Chuck Norris delivered a fatal roundhouse kick to the other piggy."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "EEOlPA7VShGuivlXBvlAZA",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/EEOlPA7VShGuivlXBvlAZA",
+    "value": "Chuck Norris chose Mudkip as his starter when playing Pokemon Emerald. This lead to the meme \"so i herd u liek mudkipz\". Therefore, anyone who answers \"No\" and knows what a Mudkip is will get roundhouse-kicked in the face by... I don't have to say who, do I?"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "-hjkiiyxqmk8lly86gelhg",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/-hjkiiyxqmk8lly86gelhg",
+    "value": "All roads lead to Chuck Norris. And by the transitive property, a roundhouse kick to the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "n20qoz6tswuf4-apuugeiw",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/n20qoz6tswuf4-apuugeiw",
+    "value": "The crossing lights in Chuck Norris's home town say \"Die slowly\" and \"die quickly\". They each have a picture of Chuck Norris punching or kicking a pedestrian."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "1gg3imfzqdgr0vw4szphdg",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/1gg3imfzqdgr0vw4szphdg",
+    "value": "The last thing you hear before Chuck Norris gives you a roundhouse kick? No one knows because dead men tell no tales."
+  }, {
+    "categories": ["dev"],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "63pymsysqiexzldn5-wdzq",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/63pymsysqiexzldn5-wdzq",
+    "value": "Chuck Norris's database has only one table, 'Kick', which he DROPs frequently."
+  }, {
+    "categories": ["dev"],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "e2gyguu0tg6di7-qykdjnw",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/e2gyguu0tg6di7-qykdjnw",
+    "value": "Chuck Norris originally appeared in the \"Street Fighter II\" video game, but was removed by Beta Testers because every button caused him to do a roundhouse kick. When asked about this glitch, Norris replied \"That's no glitch.\""
+  }, {
+    "categories": ["dev"],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "iy5n_afwrrqrj9wb6n21ww",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/iy5n_afwrrqrj9wb6n21ww",
+    "value": "Chuck Norris doesn't need garbage collection because he doesn't call .Dispose(), he calls .DropKick()."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "3KSg1quiQsaiJ4UhDVBP_Q",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/3KSg1quiQsaiJ4UhDVBP_Q",
+    "value": "Chuck Norris can roundhouse kick your face with his pinky finger."
+  }, {
+    "categories": ["celebrity"],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "nbfmksvwq3stmubxphsfbw",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/nbfmksvwq3stmubxphsfbw",
+    "value": "Saddam Hussein was not found hiding in a \"hole.\" Saddam was roundhouse-kicked in the head by Chuck Norris in Kansas, which sent him through the earth, stopping just short of the surface of Iraq."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "kDBZNuGOSGCw18QU7VjCwQ",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/kDBZNuGOSGCw18QU7VjCwQ",
+    "value": "Chuck Norris once had a heckler call him \"Chuckie\". Chuck kicked him so hard he was arrested for speeding 2 blocks away."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "RDCtS4GjQpmwByA3ytBs2A",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/RDCtS4GjQpmwByA3ytBs2A",
+    "value": "I just downloaded the new \"Roundhouse Kick\" app for my iPhone and now my screen is cracked and the phone does not work. Damn you, Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "UJbko6N2SRWjjy_Z-nNQnQ",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/UJbko6N2SRWjjy_Z-nNQnQ",
+    "value": "Jack Kevorkian was a doctor that assisted people in ending their lives voluntarily. His methods were criticized by many. Truth is, he told his patients to close their eyes and he would hold a picture of a Chuck Norris round house kick to their face and have them open their eyes. Indeed they died instantly from the shock and breaking their own necks in fear. When Chuck Norris found out, he round house kicked Kevorkian for copyright infringement."
+  }, {
+    "categories": ["religion"],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "3kf42nr6qhkll8hucjbhow",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/3kf42nr6qhkll8hucjbhow",
+    "value": "Chuck Norris has never been accused of murder because his roundhouse kicks are recognized as \"acts of God.\""
+  }, {
+    "categories": ["dev"],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "hcakrd4frju3vd-jakidqq",
+    "updated_at": "2020-01-05 13:42:19.324003",
+    "url": "https://api.chucknorris.io/jokes/hcakrd4frju3vd-jakidqq",
+    "value": "If you Google search \"Chuck Norris getting his ass kicked\" you will generate zero results. It just doesn't happen."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Wb6v8TcZTLipa8uESxGtWA",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/Wb6v8TcZTLipa8uESxGtWA",
+    "value": "Do you seriously think that McDonalds came up with the slogan \"would you like fries with that\"? Everyone knows that is what Chuck Norris tells his victims immediately proceeding a roundhouse kick to the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "SEZJrKA1STKjzQwE8Ubxqw",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/SEZJrKA1STKjzQwE8Ubxqw",
+    "value": "A Chuck Norris roundhouse kick delivered with precision accuracy to the base of your skull will cause your face to blister, putrify and later slide off the front of your head."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "HipPzAYvT4Wp3k58eWuNwQ",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/HipPzAYvT4Wp3k58eWuNwQ",
+    "value": "Chuck Norris never runs out of things to kick."
+  }, {
+    "categories": ["movie"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "nuvacfzeqomvab8yfeskxq",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/nuvacfzeqomvab8yfeskxq",
+    "value": "They had to edit the first ending of 'Lone Wolf McQuade' after Chuck Norris kicked David Carradine's ass, then proceeded to barbecue and eat him."
+  }, {
+    "categories": ["sport"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "t05rcwc4q6mjhx9zuin2qq",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/t05rcwc4q6mjhx9zuin2qq",
+    "value": "The US did not boycott the 1980 Summer Olympics in Moscow due to political reasons: Chuck Norris killed the entire US team with a single round-house kick during TaeKwonDo practice."
+  }, {
+    "categories": ["animal"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "xwjic1sws_yohsfefndaiw",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/xwjic1sws_yohsfefndaiw",
+    "value": "Chuck Norris once kicked a horse in the chin. Its decendants are known today as Giraffes."
+  }, {
+    "categories": ["food"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ojw-faz_tbglq0q4sgwt8w",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/ojw-faz_tbglq0q4sgwt8w",
+    "value": "Chuck Norris doesn't churn butter. He roundhouse kicks the cows and the butter comes straight out."
+  }, {
+    "categories": ["movie"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "zc2g3me0rnqbfankmo99hq",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/zc2g3me0rnqbfankmo99hq",
+    "value": "MacGyver immediately tried to make a bomb out of some Q-Tips and Gatorade, but Chuck Norris roundhouse-kicked him in the solar plexus. MacGyver promptly threw up his own heart."
+  }, {
+    "categories": ["music"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "0_acdyhnthyshildaipp1q",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/0_acdyhnthyshildaipp1q",
+    "value": "Who let the dogs out? Chuck Norris let the dogs out... and then roundhouse kicked them through an Oldsmobile."
+  }, {
+    "categories": ["food"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ckg3rsihqvar2uqltyx58q",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/ckg3rsihqvar2uqltyx58q",
+    "value": "When Chuck Norris was denied an Egg McMuffin at McDonald's because it was 10:35, he roundhouse kicked the store so hard it became a Wendy's."
+  }, {
+    "categories": ["movie"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "5e4voyf7t_yw-9qi8ppy6w",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/5e4voyf7t_yw-9qi8ppy6w",
+    "value": "The original draft of The Lord of the Rings featured Chuck Norris instead of Frodo Baggins. It was only 5 pages long, as Chuck roundhouse-kicked Sauron's ass halfway through the first chapter."
+  }, {
+    "categories": ["movie"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "h6t1xcbws6m8k_pduoznwg",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/h6t1xcbws6m8k_pduoznwg",
+    "value": "MacGyver can build an airplane out of gum and paper clips, but Chuck Norris can roundhouse-kick his head through a wall and take it."
+  }, {
+    "categories": ["history"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "rqcvwdgqq6amwony3nngba",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/rqcvwdgqq6amwony3nngba",
+    "value": "In the Words of Julius Caesar, \"Veni, Vidi, Vici, Chuck Norris\". Translation: I came, I saw, and I was roundhouse-kicked inthe face by Chuck Norris."
+  }, {
+    "categories": ["music"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "7tb4dwgvrwkaqg-a-wzhlq",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/7tb4dwgvrwkaqg-a-wzhlq",
+    "value": "Chuck Norris shot the sheriff, but he round house kicked the deputy."
+  }, {
+    "categories": ["sport"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "aefmqoxotvaugymnsqoezw",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/aefmqoxotvaugymnsqoezw",
+    "value": "The 1972 Miami Dolphins lost one game, it was a game vs. Chuck Norris and three seven year old girls. Chuck Norris won with a roundhouse-kick to the face in overtime."
+  }, {
+    "categories": ["science"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "qszz44pvr3iv7kzgwoedza",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/qszz44pvr3iv7kzgwoedza",
+    "value": "Chuck Norris can do a roundhouse kick faster than the speed of light. This means that if you turn on a light switch, you will be dead before the lightbulb turns on."
+  }, {
+    "categories": ["science"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "pattwbdusdgzo753xnhyxw",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/pattwbdusdgzo753xnhyxw",
+    "value": "Science Fact: Roundhouse kicks are comprised primarily of an element called Chucktanium."
+  }, {
+    "categories": ["sport"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "2o6183z1rmkus1imghxsug",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/2o6183z1rmkus1imghxsug",
+    "value": "Chuck Norris won super bowls VII and VIII singlehandedly before unexpectedly retiring to pursue a career in ass-kicking."
+  }, {
+    "categories": ["science"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "h2le0vpkstise9oetsodmw",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/h2le0vpkstise9oetsodmw",
+    "value": "Newton's Third Law is wrong: Although it states that for each action, there is an equal and opposite reaction, there is no force equal in reaction to a Chuck Norris roundhouse kick."
+  }, {
+    "categories": ["history"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "t_wyddbstys8ubos8oni4q",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/t_wyddbstys8ubos8oni4q",
+    "value": "Chuck Norris originally wrote the first dictionary. The definition for each word is as follows - A swift roundhouse kick to the face."
+  }, {
+    "categories": ["movie"],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "s4gbskbvscsc4zzybwhh3q",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/s4gbskbvscsc4zzybwhh3q",
+    "value": "Jean-Claude Van Damme once kicked Chuck Norris' ass. He was then awakened from his dream by a roundhouse kick to the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "SxTKsQ0bTAaHuQT8QFOK1Q",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/SxTKsQ0bTAaHuQT8QFOK1Q",
+    "value": "Chuck Norris roundhouse-kicked the letter 'r' out of Jonathon Woss."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "O9VYsf2wSuirvshvRThWPA",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/O9VYsf2wSuirvshvRThWPA",
+    "value": "Chuck Norris stole Christmas back from the Grinch and roundhouse kicked The Grinch's ass 84594205743920574189057209 times."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "jaHkV8rASP2SdzOg33skCA",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/jaHkV8rASP2SdzOg33skCA",
+    "value": "Chuck Norris's round house kick isn't nearly as bad when he stares you down and you burst into flames and burn to death."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "OjAI01UsQQeSdrozSnDXLw",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/OjAI01UsQQeSdrozSnDXLw",
+    "value": "Shooting stars wish Chuck Norris wouldn't roundhouse kick them."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "get7fvMwTqqp5PdFwoGY1A",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/get7fvMwTqqp5PdFwoGY1A",
+    "value": "Entropy in the universe increases one billion fold, after every roundhouse kick by Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "TAfEYk5-RPOEQZKsbLqlGg",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/TAfEYk5-RPOEQZKsbLqlGg",
+    "value": "Chuck Norris can kick you once and give you three ass whippings."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.576875",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "q8pf6tPMQ-KJUUKPMH9A7A",
+    "updated_at": "2020-01-05 13:42:19.576875",
+    "url": "https://api.chucknorris.io/jokes/q8pf6tPMQ-KJUUKPMH9A7A",
+    "value": "Chuck Norris lettered in 14 sports in high school. He would have had won letters in 15 if ass-kicking had been an officially recognized sport."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "pTVAZRxjQKOQH4NK56_aQA",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/pTVAZRxjQKOQH4NK56_aQA",
+    "value": "Whenever someone clicks on Chuck Norris' facebook page, they instantly get round house kicked"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "bHy4w6LgQ7u2_Nzer29H4Q",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/bHy4w6LgQ7u2_Nzer29H4Q",
+    "value": "Little miss muffet sat on her tuffet, until Chuck Norris roundhouse kicked her into an iceberg"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "lVJ_cOmAR4K_FGptE4FQzw",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/lVJ_cOmAR4K_FGptE4FQzw",
+    "value": "Chuck Norris once launched a massive reverse roundhouse kick at a man's face, missed and struck a conrete wall. The man died anyway from the percussion shock."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "eb4COkzuRF-fGQnnJqTFNg",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/eb4COkzuRF-fGQnnJqTFNg",
+    "value": "yo momma so ugly, Chuck Norris had to roundhouse kick her.the image of yo momma still haunts Chuck Norris to this day."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "LRYE5ZZWSnmdWYZgVbrw2w",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/LRYE5ZZWSnmdWYZgVbrw2w",
+    "value": "In the year 1735 a meteor was hurling towards earth. It suddenly stopped at the site of Chuck Norris. It asked Chuck Norris for his autograph, then Chuck Norris roundhoused kicked it back to space."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "lyxI8DpLRS2uN-5tzvkg3Q",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/lyxI8DpLRS2uN-5tzvkg3Q",
+    "value": "Chuck Norris will beat you with his nunchucks. Chuck Norris will roundhouse kick you with his Chuck Taylors. Chuck Norris will feed you to the woodchucks. Don't fuck with Chuck!!1"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "drsyP-byS-CdqgxU9JOFBA",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/drsyP-byS-CdqgxU9JOFBA",
+    "value": "Chuck Norris was banned from the Winter Olympics because the judges didnt know how to score a double-lutz flip-axle roundhouse kick to the face!!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Ii-hnG2ER0O9Qv4dUKBmIw",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/Ii-hnG2ER0O9Qv4dUKBmIw",
+    "value": "Bloody noses happen because Chuck Norris thought about roundhouse kicking you in the face, but then changed his mind."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "FT6JGPbfQ3KoHjbqo3ttQA",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/FT6JGPbfQ3KoHjbqo3ttQA",
+    "value": "a black hole is not created when a star dies, it is created when a star gets round-house kicked by Chuck Norris"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "e3cfSdJSSQm_Cw7MtXwrlg",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/e3cfSdJSSQm_Cw7MtXwrlg",
+    "value": "When Chuck Norris was born he roundhouse kicked his way out of the womb"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "X9nDrLvJSOilsRBuGvhXYA",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/X9nDrLvJSOilsRBuGvhXYA",
+    "value": "Chuck Norris doesn't edit Wikipedia, he roundhouse kicks the articles."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "SUpwpd76Q4qKiN54sskmUg",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/SUpwpd76Q4qKiN54sskmUg",
+    "value": "When GOOGLE denied Chuck Norris his own search engine, he persuaded them with a swift kick to the \"G\". http://chuckoogle.com"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "uPgkeVseTJCp8ad9rCcrwg",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/uPgkeVseTJCp8ad9rCcrwg",
+    "value": "Chuck Norris showed Paloma Faith that roundhouse kicks also hurt like love."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "NwsbprEDSxyCNTcj0g4Dxg",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/NwsbprEDSxyCNTcj0g4Dxg",
+    "value": "If you say Chuck Norris' name in Mongolia, the people there will roundhouse kick you in his honor. Their kick will be followed by the REAL roundhouse delivered by none other than Norris himself."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "XlXLbSLOQYedYDIb6KwuIg",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/XlXLbSLOQYedYDIb6KwuIg",
+    "value": "In the movie Alien 5 the Asswhoopin', movie goers were astonished to see a small Chuck Norris burst out of an alien and proceed to kick the crap out of him."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Ne-M6C0cQbC8Syy06efbJQ",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/Ne-M6C0cQbC8Syy06efbJQ",
+    "value": "Chuck Norris is in the death star trench run; Obi one kenobi: use the force chuck. Chuck Norris: F*** you old man, I use round house kick. Period The death star blew up with only one roundhouse kick and the universe was saved."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "yf8cFo-AT0GSb9C6AmH__Q",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/yf8cFo-AT0GSb9C6AmH__Q",
+    "value": "Chuck Norris was kicked out of the the NFl for refusing to wear a helmet or a pad of any kind..."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "lWL-DGFgS9-gGFfogiiXwg",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/lWL-DGFgS9-gGFfogiiXwg",
+    "value": "Hemorrhoids are a pain in the ass. And in legal terms so is a Chuck Norris roundhouse kick to 'said same'."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "K64oRq5dSv2_Op5q6cfGnw",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/K64oRq5dSv2_Op5q6cfGnw",
+    "value": "Facebook was originally Chuck Norris's personal webpage of pictures of the people he has roundhouse kicked in face.It filled up with so many people it leaked onto the internet."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "H9Pn_tS4S46JqmPScqG4HQ",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/H9Pn_tS4S46JqmPScqG4HQ",
+    "value": "Once on Blue's Clues, when Steve Burns was ill, Chuck Norris came to the show and disguised like Steve to let the children not know that Chuck Norris was on Blue's Clues. After the episode, Chuck made it through the game without clues. Steve then said \"Did you use clues?\". Then Chuck Norris took his disguise off and roundhouse kicked Steve in the face without a word. That was 16 years ago."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "yKztmVYSRJqZUOc6jwEphA",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/yKztmVYSRJqZUOc6jwEphA",
+    "value": "The so-called imaginary numbers used to be real numbers, till Chuck Norris roundhouse kicked them to oblivion. This incident is also responsible for most of the mysteries of the Universe."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "a5DdaQpLRFuNQ4eeATl7Ow",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/a5DdaQpLRFuNQ4eeATl7Ow",
+    "value": "Chuck Norris is the only true American patriot. If you suspect that .... you are gonna die by a swift roundhouse kick to your face. Nobody has ever found out who the kicker is."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "XfBtseHeQJ22g2v44J3xyA",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/XfBtseHeQJ22g2v44J3xyA",
+    "value": "Who let the dogs out? Chuck Norris let the dogs out....then roundhouse kicked them through an oldsmobile."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:19.897976",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "2ySrSZr6SfmUWVJp_N4R6Q",
+    "updated_at": "2020-01-05 13:42:19.897976",
+    "url": "https://api.chucknorris.io/jokes/2ySrSZr6SfmUWVJp_N4R6Q",
+    "value": "Facebook, not only a social networking site but also the shape your face takes when roundhouse kicked by Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.262289",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "b0eqwlSHSEGBxurQej7VTg",
+    "updated_at": "2020-01-05 13:42:20.262289",
+    "url": "https://api.chucknorris.io/jokes/b0eqwlSHSEGBxurQej7VTg",
+    "value": "When Neil Armstrong stepped onto the Moon, Chuck Norris roundhouse kicked him 900 yards and said, \"That's one giant leap for a man, and a long damn wait for me.\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.262289",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ISa5Qxe6RdCurnBCCy77eA",
+    "updated_at": "2020-01-05 13:42:20.262289",
+    "url": "https://api.chucknorris.io/jokes/ISa5Qxe6RdCurnBCCy77eA",
+    "value": "Chuck Norris once roundhouse kicked a guy called Phil. Afterwards Phil became known as Empty."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.262289",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "V3lleCmASGu56T57EvEvpA",
+    "updated_at": "2020-01-05 13:42:20.262289",
+    "url": "https://api.chucknorris.io/jokes/V3lleCmASGu56T57EvEvpA",
+    "value": "The only reason Chuck Norris didn't win an Oscar for his performance in \"Sidekicks\" is because nobody in their right mind would willingly give Chuck Norris a blunt metal object. That's just suicide"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.262289",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "WshCLRPeSz2uyZ6M0UDOvw",
+    "updated_at": "2020-01-05 13:42:20.262289",
+    "url": "https://api.chucknorris.io/jokes/WshCLRPeSz2uyZ6M0UDOvw",
+    "value": "Chuck Norris once Round-House kicked a man so fast, his foot went at the speed of light, i't traveled back in time and killed the dinosaurs. Meteor? No, Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.262289",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "SB69pXBPQ_etWBFhdkPBLQ",
+    "updated_at": "2020-01-05 13:42:20.262289",
+    "url": "https://api.chucknorris.io/jokes/SB69pXBPQ_etWBFhdkPBLQ",
+    "value": "A blind man once accidently bumped into Chuck Norris on a Texas street corner. The mere fact that he touched Chuck Norris cured the man of his blindness. But sadly, the first, last and only thing the man ever saw in his entire life was a Chuck Norris roundhouse kick to his face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.262289",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "MlnnLxjBRVmA1qtboaWy6Q",
+    "updated_at": "2020-01-05 13:42:20.262289",
+    "url": "https://api.chucknorris.io/jokes/MlnnLxjBRVmA1qtboaWy6Q",
+    "value": "For St. Patrick's day, Chuck Norris caught and crucified a Leprechaun, drank six kegs of green beer and roundhouse kicked the mayor of Boston."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.262289",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gqU6SbwLRBKMcurATkYj1Q",
+    "updated_at": "2020-01-05 13:42:20.262289",
+    "url": "https://api.chucknorris.io/jokes/gqU6SbwLRBKMcurATkYj1Q",
+    "value": "There is only two wonder in the world Chuck Norris and Chuck Norris' round house kick"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.262289",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "zkEByzvwRGCTYqLuhFRF0w",
+    "updated_at": "2020-01-05 13:42:20.262289",
+    "url": "https://api.chucknorris.io/jokes/zkEByzvwRGCTYqLuhFRF0w",
+    "value": "When a young boy asked for Chuck Norris' autograph, he gave him a good solid kick to the face and left a permanent boot mark. This is Chuck's unique autograph, and that boy's face is now worth more money than the treasure from King Tut's tomb."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.262289",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "2dE1FsdKR1yPO4m1PSbx3Q",
+    "updated_at": "2020-01-05 13:42:20.262289",
+    "url": "https://api.chucknorris.io/jokes/2dE1FsdKR1yPO4m1PSbx3Q",
+    "value": "Slash, of Guns & Roses fame, got his name when the toenails from a barefoot Chuck Norris roundhouse kick slashed the top of Slash's skull & hair off. That's why Slash now covers his deformity with a tophat."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.262289",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "NyI3R7MsR0CfUTmQqrbAfw",
+    "updated_at": "2020-01-05 13:42:20.262289",
+    "url": "https://api.chucknorris.io/jokes/NyI3R7MsR0CfUTmQqrbAfw",
+    "value": "Chuck Norris created \"Where's Waldo?\". He wasn't a fan of the name Waldo, so he round house kicked him in the face and no one has seen Waldo since...hence where's Waldo?"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.262289",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "0MHhmQwOQwGdHXf4Qa1OFw",
+    "updated_at": "2020-01-05 13:42:20.262289",
+    "url": "https://api.chucknorris.io/jokes/0MHhmQwOQwGdHXf4Qa1OFw",
+    "value": "Chuck Norris can kick you in the nuts so hard, they will fly through your body up into your head and knock out your eyeballs, effectively replacing them."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.262289",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "thA_BYpiSdS0EavenEfrpA",
+    "updated_at": "2020-01-05 13:42:20.262289",
+    "url": "https://api.chucknorris.io/jokes/thA_BYpiSdS0EavenEfrpA",
+    "value": "One round-house-kick from Chuck Norris can deliver eternal energy to Earth"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.262289",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "87oSN5qoSuqX-fy0HFAIEg",
+    "updated_at": "2020-01-05 13:42:20.262289",
+    "url": "https://api.chucknorris.io/jokes/87oSN5qoSuqX-fy0HFAIEg",
+    "value": "Chuck Norris never cries, because of this when he's sad he roundhouse kicks himself and it makes him feel better since he knows he is the only one who can survive the roundhouse."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.262289",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "iU3Kxw6fSlSmDm5B3QQs4w",
+    "updated_at": "2020-01-05 13:42:20.262289",
+    "url": "https://api.chucknorris.io/jokes/iU3Kxw6fSlSmDm5B3QQs4w",
+    "value": "Rudolph has a red nose because he got lippy and Chuck Norris roundhouse kicked him across the face several times"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ql9PGzZWTPWGEbL2FdX1jg",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/ql9PGzZWTPWGEbL2FdX1jg",
+    "value": "People say that light goes faster than anything. Not true. Once a man named Joe insulted Chuck Norris. Chuck Norris then roundhouse-kicked Joe. Less than 1 second later, Joe ended up speeding out of the universe."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "mD314iVAQW2qF7b-7KSaqg",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/mD314iVAQW2qF7b-7KSaqg",
+    "value": "haoerlkfsjkjfkjkpiku.. That's what you said after Chuck Norris roundhouse kicked your face in."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Ma1tKI0LSziPxP2uYEElAg",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/Ma1tKI0LSziPxP2uYEElAg",
+    "value": "The duck billed platypus is the result of a duck being roundhouse kicked in the head far to close to a beaver by Chuck Norris. The fact yay they have a pouch is a testament to the genetically altering properties of a Chuck Norris Roundhouse kick to the head."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "OrdHh2rYSe2hIH4eMljTNg",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/OrdHh2rYSe2hIH4eMljTNg",
+    "value": "The only reason Chuck Norris hasn't destroyed the world is because he was conferred with the honorary Nobel Peace Prize for his role in the film Sidekicks. The prize expires on December 12th, 2012."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "2hzWYC4mRaydPe2O84sPLg",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/2hzWYC4mRaydPe2O84sPLg",
+    "value": "Nelson Mandela was not released from Robben Island prison in 1990. Chuck Norris broke him out of prison, roundhouse kicked ALL the prison gaurds, and safely escorted him to the coast of Capetown. Its good to have a friend like Chuck!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "WU3IHZbfS1KmcjxrC0ZkGw",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/WU3IHZbfS1KmcjxrC0ZkGw",
+    "value": "When in Rome, Chuck Norris roundhouse-kicks you in the face wearing a toga."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "T9UfuLrLQZWpmrnHd2XNlw",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/T9UfuLrLQZWpmrnHd2XNlw",
+    "value": "The current stock market crash began when Chuck Norris faxed a Roundhouse kick to Wall Street"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "7zHhW4RGQ4CdFzQJh56uJQ",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/7zHhW4RGQ4CdFzQJh56uJQ",
+    "value": "During Osama's autopsy, study shows that a US Navy Seal did not kill Osama. Chuck Norris created a roundhouse kick so powerful, it traveled faster than the speed of light and striking through the head of Bin Laden by a mere 5 seconds faster than the US Navy Seals bullet."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "qZZjZfszSsa9Axf67Ok-tw",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/qZZjZfszSsa9Axf67Ok-tw",
+    "value": "Chuck Norris is all about that roundhouse kick, bout that roundhouse kick. No punches."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "7ojrOhlCRuO140B4BWKv2g",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/7ojrOhlCRuO140B4BWKv2g",
+    "value": "The reason Link can't speak is because he got a roundhouse kick in the throat by an unidentified bearded man \"Scientists believe him to be Chuck Norris\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "7wDjo6lHSbiEX49sqrNslg",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/7wDjo6lHSbiEX49sqrNslg",
+    "value": "Chuck Norris does not fly coach OR first class. He travels by transcontinental flying sidekick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "r7Mr8cubRF-RKgpZIRC3zA",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/r7Mr8cubRF-RKgpZIRC3zA",
+    "value": "Chuck Norris Rounhouse kicked Voldemort now he has n nose"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "H6kkWwXnTpSCtVxVkEOMqw",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/H6kkWwXnTpSCtVxVkEOMqw",
+    "value": "There was once a 51st state, known as New Idaho. It has not been heard of since it snubbed Chuck Norris as governor and was roundhouse kicked into a parallel dimension, along with Chuck's virginity and the last sonofabitch that overcooked his panda bear steaks. Chuck Norris eats his panda raw"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "SmSlZPpSQBm0oZqnRqBh_Q",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/SmSlZPpSQBm0oZqnRqBh_Q",
+    "value": "Chuck Norris once kicked a baby elephant into puberty"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "cBAzo2LZSlGc34m4GVJ4YA",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/cBAzo2LZSlGc34m4GVJ4YA",
+    "value": "The Thousand Islands used to be one big island, but then Chuck Norris's roundhouse kick smashed it into pieces."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "75-FG9jkQrysfwjr2gVPog",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/75-FG9jkQrysfwjr2gVPog",
+    "value": "Satan has a ultimate weapon to try to destroy Chuck Norris. But sadly, it worked. But then Chuck Norris revived himself and kicked Satan's ass."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "AOhjnecjRpaeO1MXu4a8Mg",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/AOhjnecjRpaeO1MXu4a8Mg",
+    "value": "if i get five good things Chuck Norris will do a roundhouse kick and kick justin bibers ass"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "-Yfa17sHSWO5FiA1uSs6wA",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/-Yfa17sHSWO5FiA1uSs6wA",
+    "value": "If you dare to look at Chuck Norris' snakeskin boots, you will get a case of bleeding hemorrhoids before kicks them up your ass."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "WzSTX5RdTcS6IBrbk_OlNw",
+    "updated_at": "2020-01-05 13:42:20.568859",
+    "url": "https://api.chucknorris.io/jokes/WzSTX5RdTcS6IBrbk_OlNw",
+    "value": "Chuck Norris is the best cop ever. Why? He can roundhouse-kick criminals straight to jail."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "wks874NuTfqdj5hY5Kmn0g",
+    "updated_at": "2020-01-05 13:42:20.841843",
+    "url": "https://api.chucknorris.io/jokes/wks874NuTfqdj5hY5Kmn0g",
+    "value": "People might think that light is the fastest thing in the universe, but try telling that to Bob. Bob was a 32 year old, cross-eyed man who just happened to look at Chuck Norris cross-eyed. This pissed Chuck Norris off, so he delivered his patented roundhouse kick to Bob's face. The skin on Bob's face peeled back, his teeth shattered, and his eyes straightened before they exploded out of his skull with enough force to kill two nearby observers. Two seconds later, Bob was three galaxies away from the edge of the universe. Five seconds later, light was like, \"What the hell!?!\" as Bob easily passed it by."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "_7RDKT5FT3O5BZsK-eS6ng",
+    "updated_at": "2020-01-05 13:42:20.841843",
+    "url": "https://api.chucknorris.io/jokes/_7RDKT5FT3O5BZsK-eS6ng",
+    "value": "Once Chuck Norris actually tried on one of his roundhouse kicks. This was also the start of World war 1 and the aftershock of the beginning of World war 2"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "MecB_WLWQFaGzIWj8OUF5Q",
+    "updated_at": "2020-01-05 13:42:20.841843",
+    "url": "https://api.chucknorris.io/jokes/MecB_WLWQFaGzIWj8OUF5Q",
+    "value": "Chuck Norris was selling a line of drinks called (Chuck Norris in a can) in a wide variety of flavors, but do to the fact that the drinks had a roundhouse kick of flavor, it had the same effect as a roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "LLKDQrJGThuqSIqKtckx8g",
+    "updated_at": "2020-01-05 13:42:20.841843",
+    "url": "https://api.chucknorris.io/jokes/LLKDQrJGThuqSIqKtckx8g",
+    "value": "The Black Eyed Peas inspiration for \"Boom Boom Pow\" is about Chuck Norris famous lethal combination. 2 straight jabs creating the \"Boom\" sound and finishes you off with the roundhouse kick to the head creating the \"Pow\" sound."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "bX7YeKZaSRSCV_hC-LgJDg",
+    "updated_at": "2020-01-05 13:42:20.841843",
+    "url": "https://api.chucknorris.io/jokes/bX7YeKZaSRSCV_hC-LgJDg",
+    "value": "Chuck Norris puts his pants on by roundhouse kicking his closet."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ZQ97i54UQKWnuERwm4KBBw",
+    "updated_at": "2020-01-05 13:42:20.841843",
+    "url": "https://api.chucknorris.io/jokes/ZQ97i54UQKWnuERwm4KBBw",
+    "value": "After Chuck Norris roundhouse kicked Theresa Caputo, the Long Island Medium in the face for being a fake, she really was able to communicate with the dearly departed...posthumously."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "OCAg_alnTjaInmwCHN2fvg",
+    "updated_at": "2020-01-05 13:42:20.841843",
+    "url": "https://api.chucknorris.io/jokes/OCAg_alnTjaInmwCHN2fvg",
+    "value": "Chuck Norris doesn't have normal white blood cells like you and I. His have a small black ring around them. This signifies that they are black belts in every form of martial arts and they roundhouse kick the shit out of viruses. That's why Chuck Norris never gets ill."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "c0aYNg0WSnKDAdZumxbM1g",
+    "updated_at": "2020-01-05 13:42:20.841843",
+    "url": "https://api.chucknorris.io/jokes/c0aYNg0WSnKDAdZumxbM1g",
+    "value": "When the Oracle told Chuck Norris he wasn't the ONE, he laughed and roundhouse kicked her in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Gp9VFhPJQP6tCb9Wh_NGqg",
+    "updated_at": "2020-01-05 13:42:20.841843",
+    "url": "https://api.chucknorris.io/jokes/Gp9VFhPJQP6tCb9Wh_NGqg",
+    "value": "It is impossible to beat Chuck Norris in rock, paper, scissors since his roundhouse kick beats all. Yes, even the bomb."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "PtalnbLyQfSvmQ7nnKyXNg",
+    "updated_at": "2020-01-05 13:42:20.841843",
+    "url": "https://api.chucknorris.io/jokes/PtalnbLyQfSvmQ7nnKyXNg",
+    "value": "Chuck Norris can kick u in the back of the face"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "hSk6DFs7T6GGkjS_d03xvw",
+    "updated_at": "2020-01-05 13:42:20.841843",
+    "url": "https://api.chucknorris.io/jokes/hSk6DFs7T6GGkjS_d03xvw",
+    "value": "Want to know what Chuck Norris' roundhouse kick feels like? Go ask Stephen Hawking"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "8V6t8tnEQh2WVMeIiGc6Ig",
+    "updated_at": "2020-01-05 13:42:20.841843",
+    "url": "https://api.chucknorris.io/jokes/8V6t8tnEQh2WVMeIiGc6Ig",
+    "value": "christmas fact: Chuck Norris can put you on the naughty list. That ends with a roundhouse kick in your face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "LsUsvXURT2uUvjMJ7sOyFw",
+    "updated_at": "2020-01-05 13:42:20.841843",
+    "url": "https://api.chucknorris.io/jokes/LsUsvXURT2uUvjMJ7sOyFw",
+    "value": "Chuck Norris once roundhouse kicked a horse in the face, its descendants are now called the giraffe"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Qqg8ijDLQ0CSk6Q99stk5A",
+    "updated_at": "2020-01-05 13:42:20.841843",
+    "url": "https://api.chucknorris.io/jokes/Qqg8ijDLQ0CSk6Q99stk5A",
+    "value": "Chuck Norris once fought with his roundhouse kick and defeated it. LOL!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "_2iW8yQSRFCPxcfgKF6Bxw",
+    "updated_at": "2020-01-05 13:42:20.841843",
+    "url": "https://api.chucknorris.io/jokes/_2iW8yQSRFCPxcfgKF6Bxw",
+    "value": "Chuck Norris super human kicking speed is the reason The Flash can be seen in slow motion running bare footed."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "wkNEIiQ6QsW73jeNR8LtPA",
+    "updated_at": "2020-01-05 13:42:20.841843",
+    "url": "https://api.chucknorris.io/jokes/wkNEIiQ6QsW73jeNR8LtPA",
+    "value": "For Chuck Norris to agree to do the losing fight scene in the \"Return of the Dragon\", Bruce Lee had to run around the universe carrying six school buses and three oil tankers on his back. On the seventh round, he also had to receive 77 roundhouse kicks to his face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "WP4sjjVtR3ODb11FPpdoew",
+    "updated_at": "2020-01-05 13:42:20.841843",
+    "url": "https://api.chucknorris.io/jokes/WP4sjjVtR3ODb11FPpdoew",
+    "value": "Chuck Norris kicked Maggie and the Ferocious Beast so hard they woke up in Nowhere Land."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.179347",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "bpwzZe5rQZuYkXm4FLFaZg",
+    "updated_at": "2020-01-05 13:42:21.179347",
+    "url": "https://api.chucknorris.io/jokes/bpwzZe5rQZuYkXm4FLFaZg",
+    "value": "Chuck Norris will roundhouse kick you to death if you laugh at Chuck Norris jokes. He will also roundhouse kick you to death if you don't laugh at Chuck Norris jokes. The choice is yours."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.179347",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "wSrGUC9UScGGlhS3mdgZVw",
+    "updated_at": "2020-01-05 13:42:21.179347",
+    "url": "https://api.chucknorris.io/jokes/wSrGUC9UScGGlhS3mdgZVw",
+    "value": "When Chuck Norris turned nine he finally kicked his parents the fuck out of his house."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.179347",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "-ePGBt5aQJKOSXkCNQsjDw",
+    "updated_at": "2020-01-05 13:42:21.179347",
+    "url": "https://api.chucknorris.io/jokes/-ePGBt5aQJKOSXkCNQsjDw",
+    "value": "A Chuck Norris roundhouse kick to the head is the reason Eric Holder can't remember his involvement in Operation Fast and Furious."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.179347",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "fSe4CfeNR0a9BMHKUdZvmw",
+    "updated_at": "2020-01-05 13:42:21.179347",
+    "url": "https://api.chucknorris.io/jokes/fSe4CfeNR0a9BMHKUdZvmw",
+    "value": "If you dont believe God exists, he doesnt believe you exist, and soon you should expect an explosive roundhouse kick to the face....(Chuck Norris is God.)"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.179347",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "pXelP8FOQcSYkDTjTRmJmg",
+    "updated_at": "2020-01-05 13:42:21.179347",
+    "url": "https://api.chucknorris.io/jokes/pXelP8FOQcSYkDTjTRmJmg",
+    "value": "Chuck Norris can stare an enemy into submission, but it's a lot more fun to roundhouse kick their ass"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.179347",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "pk4U6JakQrKvmq0iZWysOg",
+    "updated_at": "2020-01-05 13:42:21.179347",
+    "url": "https://api.chucknorris.io/jokes/pk4U6JakQrKvmq0iZWysOg",
+    "value": "Chuck Norris is the only man to ever win a game of chess in one move. A round-house kick to the head!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.179347",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "3hPN8nnHTIqw0PLHaFJtOQ",
+    "updated_at": "2020-01-05 13:42:21.179347",
+    "url": "https://api.chucknorris.io/jokes/3hPN8nnHTIqw0PLHaFJtOQ",
+    "value": "Physicists have recently discovered that the universe began when Chuck Norris roundhouse-kicked a singularity (the big bang)."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.179347",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "kAzfArpKSuqazJbsEtCU0Q",
+    "updated_at": "2020-01-05 13:42:21.179347",
+    "url": "https://api.chucknorris.io/jokes/kAzfArpKSuqazJbsEtCU0Q",
+    "value": "If a tree falls in the woods, not only did Chuck Norris hear it, he probably kicked that motherfucker over too."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.179347",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gooRuruyTMWwqyeDMS-JhA",
+    "updated_at": "2020-01-05 13:42:21.179347",
+    "url": "https://api.chucknorris.io/jokes/gooRuruyTMWwqyeDMS-JhA",
+    "value": "At McDonalds, Chuck Norris ordered breakfast at 10:40 and was denied because breakfast ends at 10:30. He got so mad , he roundhouse kicked the McDonalds so hard it became Wendy's !xpsl"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.179347",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ea6lob_hSySVeeoKwNFXVQ",
+    "updated_at": "2020-01-05 13:42:21.179347",
+    "url": "https://api.chucknorris.io/jokes/ea6lob_hSySVeeoKwNFXVQ",
+    "value": "Chuck Norris does not navigate through a corn maze... The corn merely realigns itself in chucks favor out of fear of being roundhouse kicked in the head!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.179347",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "KhFIrWOlQUq0uLk8KlTS8Q",
+    "updated_at": "2020-01-05 13:42:21.179347",
+    "url": "https://api.chucknorris.io/jokes/KhFIrWOlQUq0uLk8KlTS8Q",
+    "value": "The rotation of the Earth was actually started by a Chuck Norris roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.179347",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "0bjfwQqvRO6EL1ByqId_xQ",
+    "updated_at": "2020-01-05 13:42:21.179347",
+    "url": "https://api.chucknorris.io/jokes/0bjfwQqvRO6EL1ByqId_xQ",
+    "value": "Chuck Norris demands a 29th day of February every 4 years. We call this leap year. It's true name is leapspinkick year."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.179347",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "mRyFwX59SWWt6Y8qnUe-LQ",
+    "updated_at": "2020-01-05 13:42:21.179347",
+    "url": "https://api.chucknorris.io/jokes/mRyFwX59SWWt6Y8qnUe-LQ",
+    "value": "Chuck Norris got mad at a hamer and round house kicked it in to the first sluge hamer"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.179347",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Qsm8EU8dQTiRnKdJXoRMSw",
+    "updated_at": "2020-01-05 13:42:21.179347",
+    "url": "https://api.chucknorris.io/jokes/Qsm8EU8dQTiRnKdJXoRMSw",
+    "value": "Chuck Norris invented Herpes Duplex by roundhouse kicking a man with lip Herpes twice. Once in the mouth followed by one in the nutsack."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.179347",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "q08pwgMnRueZCloRNc-hYw",
+    "updated_at": "2020-01-05 13:42:21.179347",
+    "url": "https://api.chucknorris.io/jokes/q08pwgMnRueZCloRNc-hYw",
+    "value": "A Chuck Norris flying roundhouse kick in the face has been known to cause a yellow, pus filled abscess in hemorrhoidal tissue."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.179347",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "DJ718neqSkKLvcTVnAqdZA",
+    "updated_at": "2020-01-05 13:42:21.179347",
+    "url": "https://api.chucknorris.io/jokes/DJ718neqSkKLvcTVnAqdZA",
+    "value": "Chuck Norris doesn't have a shadow anymore because he roundkicks a wall if it appears"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.455187",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ZMmIfKkxQtCBOnX4Io5vfw",
+    "updated_at": "2020-01-05 13:42:21.455187",
+    "url": "https://api.chucknorris.io/jokes/ZMmIfKkxQtCBOnX4Io5vfw",
+    "value": "Once god asked Chuck Norris \"what do you want?\". Chuck Norris retorted \"what the fuck do YOU want?\" and proceeded to roundhouse kick him mercilessly. Ever since god went into hiding and is rarely seen by anyone ever again."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.455187",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "17UJlZXTQBugdwnyj2NFmQ",
+    "updated_at": "2020-01-05 13:42:21.455187",
+    "url": "https://api.chucknorris.io/jokes/17UJlZXTQBugdwnyj2NFmQ",
+    "value": "Chuck Norris hates Internet Explorer. And he is going to roundhouse kick the fuckin shit out of you if you use it. Get Firefox!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.455187",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "E_i7e2AWQkWiKlRRLn9UtA",
+    "updated_at": "2020-01-05 13:42:21.455187",
+    "url": "https://api.chucknorris.io/jokes/E_i7e2AWQkWiKlRRLn9UtA",
+    "value": "Chuck Norris blew up the Death Star with a roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.455187",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "M7TQyAxcR_uxa0dvTXH3Hw",
+    "updated_at": "2020-01-05 13:42:21.455187",
+    "url": "https://api.chucknorris.io/jokes/M7TQyAxcR_uxa0dvTXH3Hw",
+    "value": "Chuck Norris was ask to join the cast of The Exspendables, but once Stallone offered Chuck the part.... he did a roundhouse kick, and said with a grin.. Sly you know as well as anyone.. Chuck Norris is not expendable."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.455187",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "QL1NFpIdQRC0ilhqeqYiqA",
+    "updated_at": "2020-01-05 13:42:21.455187",
+    "url": "https://api.chucknorris.io/jokes/QL1NFpIdQRC0ilhqeqYiqA",
+    "value": "Chuck Norris can stare down a Buckingham Palace guard. After he does that, he roundhouse kicks their stupid furry hats off their heads."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.455187",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "wphkHUtSQUSeox0fMjuvtQ",
+    "updated_at": "2020-01-05 13:42:21.455187",
+    "url": "https://api.chucknorris.io/jokes/wphkHUtSQUSeox0fMjuvtQ",
+    "value": "no one really knows why Sergio Busquets kicked the ball over the bars against Chelsea until now he was threatened by Chuck Norris in the crowd telling him you score this son and you will never be at peace because you will be living in fear thinking when you will feel the wrath of my roundhouse kick"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.455187",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "jIKN_6PuSjiSTSg7o5avNQ",
+    "updated_at": "2020-01-05 13:42:21.455187",
+    "url": "https://api.chucknorris.io/jokes/jIKN_6PuSjiSTSg7o5avNQ",
+    "value": "A man once took Chuck Norris to court for alleged assult. After the shortest jury deliberation in history, the man was found guilty of first-degree Talking Shit About Mr. Norris and sentenced to death by instant roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.455187",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "MHycK9R7R-uIPrhgyceVBw",
+    "updated_at": "2020-01-05 13:42:21.455187",
+    "url": "https://api.chucknorris.io/jokes/MHycK9R7R-uIPrhgyceVBw",
+    "value": "Jesus didn't rise and ascend to the heavens on the 3rd day. Chuck Norris round kick him back to life and simultaneously killed him again sending him to heaven."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.455187",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "w20vVcZUS6S0foEFyCPNRQ",
+    "updated_at": "2020-01-05 13:42:21.455187",
+    "url": "https://api.chucknorris.io/jokes/w20vVcZUS6S0foEFyCPNRQ",
+    "value": "Chuck Norris is solving world hunger one kick at a time."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.455187",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "lcM9lOyASPSgH6ZgogZ94g",
+    "updated_at": "2020-01-05 13:42:21.455187",
+    "url": "https://api.chucknorris.io/jokes/lcM9lOyASPSgH6ZgogZ94g",
+    "value": "Chuck Norris became Grand ChessMaster when he defeated his opponents only by using one piece (his leg) and on his first move (the roundhouse kick). He never lost."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.455187",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "uqgBYN06SDi9wbQM3A2iKQ",
+    "updated_at": "2020-01-05 13:42:21.455187",
+    "url": "https://api.chucknorris.io/jokes/uqgBYN06SDi9wbQM3A2iKQ",
+    "value": "Chuck Norris can kick-start a car.Chuck Norris sleeps with a piollw under his gun.Chuck Norris hates Raymond.It took 7 women,﻿ 4 doctors, and 3 hospitals to give birth to Chuck Norris.Apple pays Chuck Norris 99cents every time he listens to a song.Chuck Norris can touch MC Hammer.Stephen Hawkings is the only man to have survived an encounter with Chuck Norris.Chuck Norris can hold Puff Daddy down.When Chuck Norris plays monopoly it affects the whole economy."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.455187",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "b6fFcr7MQc6g32LXVpCUGw",
+    "updated_at": "2020-01-05 13:42:21.455187",
+    "url": "https://api.chucknorris.io/jokes/b6fFcr7MQc6g32LXVpCUGw",
+    "value": "It is not the final countdown Chuck Norris roundhouse kicked it and made it the first"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.455187",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ulctbZPiTu6mkhItuoNwTw",
+    "updated_at": "2020-01-05 13:42:21.455187",
+    "url": "https://api.chucknorris.io/jokes/ulctbZPiTu6mkhItuoNwTw",
+    "value": "Chuck Norris oncd spent his entire weekend eating Duracell Batteries. He did this so that on Monday he could crap out a fire-developed tank round to fire at the short bus that drives by his house. He then give the bus a roundhouse kick to the face!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.455187",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "2OV7FdbfRBW_RlikjcRokw",
+    "updated_at": "2020-01-05 13:42:21.455187",
+    "url": "https://api.chucknorris.io/jokes/2OV7FdbfRBW_RlikjcRokw",
+    "value": "Chuck Norris once round-house kicked a man in a call centre. Over the phone."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.455187",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "-a5kN5lBQ7-37pmLfv12bQ",
+    "updated_at": "2020-01-05 13:42:21.455187",
+    "url": "https://api.chucknorris.io/jokes/-a5kN5lBQ7-37pmLfv12bQ",
+    "value": "Chuck Norris can smell Uranas. He can also smell your anus. And with only one roundhouse kick, he can make your anus look like Uranas."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.455187",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "__fZcNikT6-C_kAOodAiIg",
+    "updated_at": "2020-01-05 13:42:21.455187",
+    "url": "https://api.chucknorris.io/jokes/__fZcNikT6-C_kAOodAiIg",
+    "value": "Chuck Norris can roundhouse kick your face... with his hands."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.455187",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "hjZKeGg2Q1uMJSyiebCmsQ",
+    "updated_at": "2020-01-05 13:42:21.455187",
+    "url": "https://api.chucknorris.io/jokes/hjZKeGg2Q1uMJSyiebCmsQ",
+    "value": "Chuck Norris does not believe in violence. He only believes in solving problems with an explosive roundhouse kick to the face. And if you argue that a roundhouse kick is violence, Chuck Norris can solve that problem too."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.795084",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Rh3sCa0RR3SPMO--BXVjpg",
+    "updated_at": "2020-01-05 13:42:21.795084",
+    "url": "https://api.chucknorris.io/jokes/Rh3sCa0RR3SPMO--BXVjpg",
+    "value": "Chuck Norris practices his roundhouse kicks: a. Anywhere he wants B. Chuck Norris doesn't need to practice C. On your face D. All of the above Hint: The answer is 'd'"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.795084",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "njocLy4CQ7KoXw59q4eWqg",
+    "updated_at": "2020-01-05 13:42:21.795084",
+    "url": "https://api.chucknorris.io/jokes/njocLy4CQ7KoXw59q4eWqg",
+    "value": "Chuck Norris once tried to defeat Garry Kasparov in a game of chess. When Norris lost, he won in life by roundhouse kicking Kasparov in the side of the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.795084",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "HHyCni9HQqihMSjWzyc8iQ",
+    "updated_at": "2020-01-05 13:42:21.795084",
+    "url": "https://api.chucknorris.io/jokes/HHyCni9HQqihMSjWzyc8iQ",
+    "value": "The first man to be kicked in the groin by Chuck Norris coined the term \"pisshell,\" just before he cried to death."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.795084",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ZjrM9K2WTNCgJwCV1-AUrg",
+    "updated_at": "2020-01-05 13:42:21.795084",
+    "url": "https://api.chucknorris.io/jokes/ZjrM9K2WTNCgJwCV1-AUrg",
+    "value": "Chuck Norris roundhouse kicked superman and turned him into the late Christopher Reeve."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.795084",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "dFdmcnPNQRuKv663kwbCAg",
+    "updated_at": "2020-01-05 13:42:21.795084",
+    "url": "https://api.chucknorris.io/jokes/dFdmcnPNQRuKv663kwbCAg",
+    "value": "Once while walking a nature trail, Chuck Norris observed a hornets nest hanging from a tree limb. He knocked it down with a roundhouse kick just for the fun of pulling the stingers out of the ass of each one of 500 pissed off hornets."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.795084",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "cKbLFZ8uS1WrpLxVly_CaA",
+    "updated_at": "2020-01-05 13:42:21.795084",
+    "url": "https://api.chucknorris.io/jokes/cKbLFZ8uS1WrpLxVly_CaA",
+    "value": "Slenderman runs from Chuck Norris. Its also the reason why Slenderman has no eyes.....Chuck Norris roundhoused kicked his face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.795084",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "c188cQArT1eVCJkHCPjZhw",
+    "updated_at": "2020-01-05 13:42:21.795084",
+    "url": "https://api.chucknorris.io/jokes/c188cQArT1eVCJkHCPjZhw",
+    "value": "Little known fact: Chuck Norris shot J.R. after he killed him with a spectacular roundhouse kick to the forehead."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.795084",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "_MWPMYLpS-yE_JdeUxxYYQ",
+    "updated_at": "2020-01-05 13:42:21.795084",
+    "url": "https://api.chucknorris.io/jokes/_MWPMYLpS-yE_JdeUxxYYQ",
+    "value": "Someone ask Chuck Norris waht kind of music he listened to. You fool he answered I don't listen to music music listens to me. He then proceeded with a roundhouse kick to the face while the National Anthem listned in the background."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.795084",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "hMjLKQYKSVyBR7ZpepvqMQ",
+    "updated_at": "2020-01-05 13:42:21.795084",
+    "url": "https://api.chucknorris.io/jokes/hMjLKQYKSVyBR7ZpepvqMQ",
+    "value": "Chuck Norris could bend Uri Geller with his mind. But he would prefer to brutally roundhouse kick him in the face if he ever comes back to America."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.795084",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "-phR6yD-T5e_Ou8zc6EQLA",
+    "updated_at": "2020-01-05 13:42:21.795084",
+    "url": "https://api.chucknorris.io/jokes/-phR6yD-T5e_Ou8zc6EQLA",
+    "value": "Chuck Norris made a new religion painism where you go to church and he round house kicks for an hour"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.795084",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "WPUuVmPjQ-GesRaYVvZuIQ",
+    "updated_at": "2020-01-05 13:42:21.795084",
+    "url": "https://api.chucknorris.io/jokes/WPUuVmPjQ-GesRaYVvZuIQ",
+    "value": "Chuck Norris' grandfather presented him with an alarm clock on his 7th birthday. Chuck Norris roundhouse kicked and broke the clock into a million pieces. Nothing alarms Chuck Norris. Btw Chuck Norris' grandfather is also Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.795084",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "I9QjP-dbSVW77BHxELZZZw",
+    "updated_at": "2020-01-05 13:42:21.795084",
+    "url": "https://api.chucknorris.io/jokes/I9QjP-dbSVW77BHxELZZZw",
+    "value": "If you roundhouse kick Chuck Norris, Chuck Norris will say: \"Congratulations. You are my Roundhouse Kick buddy!\" If i were a Roundhouse Kick Buddy i would go crazy! XD"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.795084",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "0imTOm6-TFCnjSiurQEkHQ",
+    "updated_at": "2020-01-05 13:42:21.795084",
+    "url": "https://api.chucknorris.io/jokes/0imTOm6-TFCnjSiurQEkHQ",
+    "value": "Chuck Norris doesn't pedal a bike. He roundhouse-kicks one of the pedals to go a mile."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.795084",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "E0I1cu97QOC5okftdFVFRg",
+    "updated_at": "2020-01-05 13:42:21.795084",
+    "url": "https://api.chucknorris.io/jokes/E0I1cu97QOC5okftdFVFRg",
+    "value": "Bob the Builder. Can we fix it. Chuck Norris already did. With a roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.795084",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "GjMd_d5KQjOhGLZ0u__LTA",
+    "updated_at": "2020-01-05 13:42:21.795084",
+    "url": "https://api.chucknorris.io/jokes/GjMd_d5KQjOhGLZ0u__LTA",
+    "value": "If there was a game about Chuck Norris you'd be scared to play it because every time you'd open it up it would roundhouse kick you in the balls."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.795084",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Ki2cRkWER1mmAbYdvEm_wA",
+    "updated_at": "2020-01-05 13:42:21.795084",
+    "url": "https://api.chucknorris.io/jokes/Ki2cRkWER1mmAbYdvEm_wA",
+    "value": "Chuck Norris can roundhouse kick your skeleton out of your body and wear your skin as a costume just before he goes on his daily five o'clock killing spree."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:21.795084",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "5SdD2h0oQxOD4IAZCAy85w",
+    "updated_at": "2020-01-05 13:42:21.795084",
+    "url": "https://api.chucknorris.io/jokes/5SdD2h0oQxOD4IAZCAy85w",
+    "value": "One day Chuck Norris roundhouse kicked a building killing thousands of people while drinking a diet coke on a sunny day."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ckbl3fKNQBmflOaPq_TZNA",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/ckbl3fKNQBmflOaPq_TZNA",
+    "value": "If you see Chuck Norris kick someone out of a window, you just know he's gonna land on a conveniently-placed spike."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "S2c9Nk7-SzyTmNzFH6Z0Zw",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/S2c9Nk7-SzyTmNzFH6Z0Zw",
+    "value": "Chuck Norris, unlike Santa Clause, gives you a gift every day of the year. His gift is not roundhouse kicking you in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "_pNDVaudRISSjG1cVYTM3Q",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/_pNDVaudRISSjG1cVYTM3Q",
+    "value": "Chuck Norris once beat Bobby Fischer at chess in a single move. That move was a roundhouse kick. That's why Fisher went crazy and died at the same age as the squares on a chessboard."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Ucx7siMoTUqbpbZW6vLhsg",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/Ucx7siMoTUqbpbZW6vLhsg",
+    "value": "Chuck Norris could drop kick you thru the telephone on an international long distance call, reverse the charges and you would accept them."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "h1wmJ-T6SzmLyJjtJRV0cQ",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/h1wmJ-T6SzmLyJjtJRV0cQ",
+    "value": "Chuck Norris recently guested on Hardcore Pawn, where he sold some pocket lint for 8.5 million dollars. Then he brutally roundhose kicked the owner for not actually having any porn."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "PH_Tatr7S0ib6eviht1A0w",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/PH_Tatr7S0ib6eviht1A0w",
+    "value": "Chuck Norris invented time travel. He's roundhouse kicked 170,000 people into next week thus far."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "rv5BnPpGSIK9fYPSOCAGuQ",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/rv5BnPpGSIK9fYPSOCAGuQ",
+    "value": "Max Headroom is the result of Chuck Norris kicking Duke Nukem's ass."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "hhITgBqTQgOwYlDfhjCWPg",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/hhITgBqTQgOwYlDfhjCWPg",
+    "value": "Check yourself before you wreck yourself....... Cos roundhouse kicks from Chuck Norris is bad for your health."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "SUluEumSSWqDibkGiJ-VUA",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/SUluEumSSWqDibkGiJ-VUA",
+    "value": "Chuck Norris roundhouse-kicked Mike Tyson, permanently damaging the \"social\" and \"speech\" parts of the brain. This is why Mike Tython talkth like thith and has an Antithocial Perthonality Dithorder."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "YIJeclypScWCOV8qS96DKA",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/YIJeclypScWCOV8qS96DKA",
+    "value": "If Chuck Norris wanted you dead, he'd kick you so hard that the force causes your body to accelerate past light speed, tear open the fabric of space time, and your corpse go back in time and kill your past self, thus erasing your existence from the entire universe."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "x2uiPwFSTWeeH6uNZiAqaA",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/x2uiPwFSTWeeH6uNZiAqaA",
+    "value": "When the mother of Chuck Norris was pregnant she could feel him moving in her stomache. Little did she know, he was perfecting his Round House Kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "GIPWGds9QQmZYpRyeD2JKA",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/GIPWGds9QQmZYpRyeD2JKA",
+    "value": "Chuck Norris once ate at a restaurant and finished his meal ask the waiter to come over he wanted to give him something. the waiter thinking it was a round house kick killed him self and everyone within 10 miles killed them self. Chuck Norris laughed and said fine ill keep the tip. But annoyed that everyone thought it was a round house kick Chuck Norris brought everyone back to life and killed them again for thinking that. Moral of the story when Chuck Norris gives you something TAKE IT LIKE A MAN IDIOT"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "r43suA29S7aG10UOYngO7Q",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/r43suA29S7aG10UOYngO7Q",
+    "value": "Chuck Norris once roundhouse kicked a mattress for refusing to share with him."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "HEp6dFQYRdWCfZqWL-3A9A",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/HEp6dFQYRdWCfZqWL-3A9A",
+    "value": "a long time ago Chuck Norris kicked the world so hard that its still spinning today."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "yuUFHnRzQfmELvsZ8t_6QQ",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/yuUFHnRzQfmELvsZ8t_6QQ",
+    "value": "A single death is a tragedy; Chuck Norris roundhouse kick to the face is a statistic."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "p-WwzueNT5aSw7JqV-pUwQ",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/p-WwzueNT5aSw7JqV-pUwQ",
+    "value": "Einstein's Theory of Relativity states that nothing can travel faster than light... except Chuck Norris's roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "FsFNAG1EStG48HA47LAtDA",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/FsFNAG1EStG48HA47LAtDA",
+    "value": "There is only one thing that could possibly stop Messi's unstoppable form Chuck Norris's roundhouse kick"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "cfVeZG5aQWKPdbwJPutOwA",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/cfVeZG5aQWKPdbwJPutOwA",
+    "value": "Autumns occur when Chuck Norris roundhouse kicks every tree in existence."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "bsdmfFk5Qo6kgorlKiR6LQ",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/bsdmfFk5Qo6kgorlKiR6LQ",
+    "value": "Contrary to popular belief Chuck Norris began the website www.roundhousekicktothefacebook.com, it has since been shortened to facebook.com and filled with people Mr. Norris will roundhouse kick to the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "saRcVemARkKXENIqnsRmlg",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/saRcVemARkKXENIqnsRmlg",
+    "value": "Chuck Norris can disembowel a sandstorm with a roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.089095",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "rAdErZveR4mP_QkJ810-5g",
+    "updated_at": "2020-01-05 13:42:22.089095",
+    "url": "https://api.chucknorris.io/jokes/rAdErZveR4mP_QkJ810-5g",
+    "value": "Chuck Norris doesn't cry over spilled milk, because it was his roundhouse kick that split the cow in half."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Hd5_vYnUR0S1nlkWIrU2NQ",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/Hd5_vYnUR0S1nlkWIrU2NQ",
+    "value": "When Chuck Norris enjoys some spare time from kicking ass he sits in his tool shed whacking off."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "cOPt7J65So2tPRMWkcdXJQ",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/cOPt7J65So2tPRMWkcdXJQ",
+    "value": "Chuck Norris can kill a werewolf with a wooden stake, a vampire with a silver bullet, and anything with a roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "X1qsVDIhQ96YWroPCtQunw",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/X1qsVDIhQ96YWroPCtQunw",
+    "value": "Someone once told Chuck Norris his hair looked good. He roundhouse kicked him in the face and told him that he made the hair look good."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "K6xD8c8YTA-jgL0Yi-pINQ",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/K6xD8c8YTA-jgL0Yi-pINQ",
+    "value": "The song \"Final Countdown\" is about a man's last second after being roundhouse kicked by Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "CxSRLvKPSeu49mTbWf0XHg",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/CxSRLvKPSeu49mTbWf0XHg",
+    "value": "Chuck Norris roundhouse kicked a man so hard, he turned into a gorilla!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "JiMoo9CcS4OmmLMxBmuv7A",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/JiMoo9CcS4OmmLMxBmuv7A",
+    "value": "Every Easter, Chuck Norris like to celebrate by using his powers as a necromancer to resurrect Jesus Christ, then immediately roundhouse kick him to death again."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "7ESlxfCWSiGmRdW6d19PnA",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/7ESlxfCWSiGmRdW6d19PnA",
+    "value": "Everyone is entitled to Chuck Norris' opinion...or a roundhouse kick to the jaw."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "sv9PiGlRQ0KZ_JJy9gFmYQ",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/sv9PiGlRQ0KZ_JJy9gFmYQ",
+    "value": "Chuck Norris put humpty dumpty back together again, only to roundhouse kick him in the face. Later Chuck dined on scrambled eggs with all the king's horses and all the king's men. The king himself could not attend for unspecified reasons. Coincidentally, the autopsoy revealed the cause of death to be a roundhouse kick to the face. There is only one King."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "VqPP9QAOSyOShQS_PuHSXQ",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/VqPP9QAOSyOShQS_PuHSXQ",
+    "value": "A kid once had test. Not knowing what to do, the kid wrote \"Chuck Norris\" for every answer. He got a perfect score, but Chuck Norris came and roundhouse kicked him for using his name in vain."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "I0Tcx7aXRI2M-AnR3Yx3bw",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/I0Tcx7aXRI2M-AnR3Yx3bw",
+    "value": "Chuck Norris roundhouse-kicked the man who shot Liberty Vallance."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "9DIfzC0kSUyg18Fguhv2-g",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/9DIfzC0kSUyg18Fguhv2-g",
+    "value": "Norris 25:17. \"The path of the righteous man (me) is beset on all sides by the inequities of the dumbasses and the tyranny of suited girlymen. Blessed is he who, in the name of charity and good will, sends boxes of cigars and crates of beer to me. For I am truly the Mack Daddy and the killer of lost children. And I will roundhouse kick thee with great vengeance and furious anger those who attempt to look at me sideways. And you will know I am the Lord, Chuck Norris, when I lay my vengeance upon you.\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "vKhwIvz-QZWwMRr3ct17SQ",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/vKhwIvz-QZWwMRr3ct17SQ",
+    "value": "Elmo was originally blue and had a deep voice. Then Chuck Norris roundhouse kicked him 4 times. The last kick changed his voice."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "bQkaXL0yTu-ClefWChemwA",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/bQkaXL0yTu-ClefWChemwA",
+    "value": "Chuck Norris doesn't drink often. But when he does, he prefers to kick 'the most interesting man in the word' in the ass & take his Dos Equis."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "XJ68YH8ZQAuwhF9hQZ_03w",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/XJ68YH8ZQAuwhF9hQZ_03w",
+    "value": "When Chuck Norris kicks air, someone still gets hurt."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Xs8klqJHQG-p6DnKb_2Oaw",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/Xs8klqJHQG-p6DnKb_2Oaw",
+    "value": "The single most successful anti-smoking measure was a commercial in the 1980's. In the commercial, there is a man smoking a cigarette. A voice then exclaims \"Smoking will kill you.\" Nothing happens, until Chuck Norris blasts through the wall and kills the man with a single round house kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "IRxZL6wHTAaDsJKZeukSAg",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/IRxZL6wHTAaDsJKZeukSAg",
+    "value": "Never brag to Chuck Norris that you have the latest smart phone, he will roundhouse kick you in the face and tell you \"there is no app for that\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "KCFRbf6gSP2N7uBXNGSuVQ",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/KCFRbf6gSP2N7uBXNGSuVQ",
+    "value": "A journey of a thousand miles starts with a single step... and of course can be ended with a single brutal Chuck Norris spinning snap kick to the side of the face. So think about that."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "DhyXeiX0RSeGHbmSohvYMA",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/DhyXeiX0RSeGHbmSohvYMA",
+    "value": "Chuck Norris invented Breeding so that he could Roundhouse Kick Newborns.... Twice"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "W6Nom6HSRs6dWAuwt-SK6A",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/W6Nom6HSRs6dWAuwt-SK6A",
+    "value": "Surprisingly, the only Street Fighter II move based on one of Chuck Norris' was Chun-Li's. Chuck Norris prefers to travel by performing four upside-down double-roundhouse kicks per second."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "kae-_FEgR82EpDNEtxI71w",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/kae-_FEgR82EpDNEtxI71w",
+    "value": "Chuck Norris not only kicks ass and takes names, he kills people and collects their souls."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "AId2yQsCTEK0sc8bYBrEiQ",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/AId2yQsCTEK0sc8bYBrEiQ",
+    "value": "If Chuck Norris kicked your ass, then went back in time and kicked your ass again, did he ever kick your ass in the first place?"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "o71ta6aKQRKqi5_KY205qg",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/o71ta6aKQRKqi5_KY205qg",
+    "value": "Santa Claus attaches his sleigh to Chuck Norris's jumping side kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "quQ0YJfSRCKRqQIhau_tZg",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/quQ0YJfSRCKRqQIhau_tZg",
+    "value": "A black hole singularity is actually the end result of a Chuck Norris roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "aEVUWI-cQASYahoQie4cUA",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/aEVUWI-cQASYahoQie4cUA",
+    "value": "Chuck Norris will roundhouse kick your ass unless you submit a Chuck Norris fact."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.701402",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Ajo2ltf3SeyqGhiS0zhlaw",
+    "updated_at": "2020-01-05 13:42:22.701402",
+    "url": "https://api.chucknorris.io/jokes/Ajo2ltf3SeyqGhiS0zhlaw",
+    "value": "Chuck Norris roundhouse kicks the snot out elephants & hangs them on the ceiling for birthday party decorations."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "eYmwHJHyTxC5QO6fXzddDA",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/eYmwHJHyTxC5QO6fXzddDA",
+    "value": "Chuck Norris roundhouse kicked Neo out of Zion, now Neo is \"The Two\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "0ZYuJ5HFRsqW45DoOSkPuQ",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/0ZYuJ5HFRsqW45DoOSkPuQ",
+    "value": "The automobile air bag was originally a failed invention to try and soften a blow from a Chuck Norris roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "rJNAtvjFRPCPfNzIyiBSMQ",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/rJNAtvjFRPCPfNzIyiBSMQ",
+    "value": "You become aware that Chuck Norris has just roundhouse kicked you in the face when you reach over your shoulder to rub something off your back and find out it's the floor."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "YdFx7-qTQ_eYl2QDukhu-w",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/YdFx7-qTQ_eYl2QDukhu-w",
+    "value": "I kicked Chuck Norris'sjrago irjft awoe rfa;e jh;ao werjfa olhergaklashfg eo ifuy porhg z;irgf;salirhg"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "o46rlpv8Sgyewwmk-iaptA",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/o46rlpv8Sgyewwmk-iaptA",
+    "value": "There was supposed to be a Office 2008 but the spell check on word failed to capitalize Chuck Norris's name so he round house kicked it out of existence."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gqH5AbTgQwiZXbbR15tP0Q",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/gqH5AbTgQwiZXbbR15tP0Q",
+    "value": "Remember what happens in the movie \"Candyman\" when you say his name three times if you try to say Chuck Norris name three times you wouldn't get the chance to say the last two before he roundhouse kicks your face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "qev0RvU9S7WlusV8_KGgxw",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/qev0RvU9S7WlusV8_KGgxw",
+    "value": "Chuck Norris will never die. Every time Death pays him a visit, Chuck Norris will kick his ass with a roundhouse kick in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Ol7c0HG_TkuP7eFSl4dLFQ",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/Ol7c0HG_TkuP7eFSl4dLFQ",
+    "value": "Chuck Norris' favorite video is the tape from the movie \"the ring\" Ironically, if you watch the movie \"sidekicks\", and dont like it, Chuck Norris will roundhouse kick you and when they find your corpse, your face will look the same as the people who died from watching the tape in \"the ring\"."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "amaoL5HsTQ-GwD_bRX9mQw",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/amaoL5HsTQ-GwD_bRX9mQw",
+    "value": "Einstein may have invented the therory of relativity- Chuck Norris invented the reality of kicking ass."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "QYcPJgd5S_CXt5omRN2iFQ",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/QYcPJgd5S_CXt5omRN2iFQ",
+    "value": "upChuck is a term now used to describe how far in the air you fly when Chuck Norris kicks your ass."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "HJnEggp1SXyvA6wHEv9iBw",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/HJnEggp1SXyvA6wHEv9iBw",
+    "value": "It goes without saying that non-smoking laws do NOT apply to Chuck Norris. Gas stations, maternity wards, fireworks factories, the White House, wherever he is, he'll strike a match off your face an blow a huge plume into it. Then roundhouse kick you."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "IuzY1qAwS2afrXH8UTS6Jw",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/IuzY1qAwS2afrXH8UTS6Jw",
+    "value": "Chuck Norris isn't as tuff as everyone says. What was that? It just sounded like someone kicked my door down."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gbadb6sYTpiuZNWuU4t7hw",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/gbadb6sYTpiuZNWuU4t7hw",
+    "value": "Chuck Norris created his own language with signs such as roundhouse kicking people in the face. So if Chuck Norris is kicking your ass one day, he may just be saying that he likes your hat."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Ia6cpvjQQkW8HYf0QAgIPg",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/Ia6cpvjQQkW8HYf0QAgIPg",
+    "value": "Chuck Norris can do a round house kick on his knees."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "jXl332D3Ttmmn-eraYC9iA",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/jXl332D3Ttmmn-eraYC9iA",
+    "value": "When Chuck Norris smiles, someone dies. When he's smiling while roundhouse kicking someone, then two people die."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "xPTOVbWVRQGWW68qWEfmSw",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/xPTOVbWVRQGWW68qWEfmSw",
+    "value": "10 out of 10 Doctors agree that a Chuck Norris roundhouse kick will kill every thing in a 10 mile radius."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "cL8IPfsAR-G1jLrPjrpKZA",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/cL8IPfsAR-G1jLrPjrpKZA",
+    "value": "Chuck Norris can roundhouse kick you into yourself, and then kick the you that's within yourself into outer space."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "MmBqKlbxTWKXSSkgp4umGw",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/MmBqKlbxTWKXSSkgp4umGw",
+    "value": "Chuck Norris once went fishing, but then ended up fighting a shark and roundhouse kicking it into the Pacific Ocean."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "k7N24hUgRee_VgHlv-AIpQ",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/k7N24hUgRee_VgHlv-AIpQ",
+    "value": "Chuck Norris will kick your ass by way of your head."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "f5WnfXPETCyIgi5f_N_qQw",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/f5WnfXPETCyIgi5f_N_qQw",
+    "value": "Once Chuck Norris Kicked a football , Now We are calling it as Moon."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "J87BuhadSOChapnjUb4jlg",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/J87BuhadSOChapnjUb4jlg",
+    "value": "Filming on location for Walker: Texas Ranger, Chuck Norris brought a stillborn baby lamb back to life by giving it a prolonged beard rub. Shortly after the farm animal sprang back to life and a crowd had gathered, Chuck Norris roundhouse kicked the animal, breaking its neck, to remind the crew once more that Chuck giveth, and the good Chuck, he taketh away."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "KOy7Z36MSYueY_ib6NTfpg",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/KOy7Z36MSYueY_ib6NTfpg",
+    "value": "The victims of Michael Myers run around helpless and scared to death until he finds them and stab them. but Michael Myers is always on the run cause he's terrified of how hard Chuck Norris will roundhouse kick him when he finds him."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Fi7I2cQzTeiysPsfHKLCqg",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/Fi7I2cQzTeiysPsfHKLCqg",
+    "value": "Chuck Norris once stumbled upon a website with random facts about himself. Although he was flattered, he sent an email to each person who submitted an untrue fact. Upon opening the email, a leather cowboy boot came through each computer screen and roundhouse kicked everyone within a 30 meter radius."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "W6a_c6yoSAGLNTRdaBX7_Q",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/W6a_c6yoSAGLNTRdaBX7_Q",
+    "value": "The only child ever to survive a roundhouse kick by Chuck Norris was Gary Coleman. He has not grown since."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:22.980058",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "p3vkOglzTn6X6Ms72_mT7A",
+    "updated_at": "2020-01-05 13:42:22.980058",
+    "url": "https://api.chucknorris.io/jokes/p3vkOglzTn6X6Ms72_mT7A",
+    "value": "Chuck Norris got so pissed off at IE6 he roundhouse kicked it and to this day it still can't render css properly."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.240175",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "AwZt7wDeT9u9okgbFr5f7A",
+    "updated_at": "2020-01-05 13:42:23.240175",
+    "url": "https://api.chucknorris.io/jokes/AwZt7wDeT9u9okgbFr5f7A",
+    "value": "Chuck Norris knows Italian fluently, but prefers to let his roundhouse kicks to do the talking when in Rome."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.240175",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "v-oznknhRNyPAsmONo-7YA",
+    "updated_at": "2020-01-05 13:42:23.240175",
+    "url": "https://api.chucknorris.io/jokes/v-oznknhRNyPAsmONo-7YA",
+    "value": "When a waiter asks Chuck Norris what he wants to drink, he responds with a roundhouse kick to the face and collecting the waiter's tears in a glass. He drinks them and then tells the waiter for ice next time."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.240175",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "XKkxqppkRpa2pHXIQ1d6Ww",
+    "updated_at": "2020-01-05 13:42:23.240175",
+    "url": "https://api.chucknorris.io/jokes/XKkxqppkRpa2pHXIQ1d6Ww",
+    "value": "A lady once asked Chuck Norris to kiss her baby. He thought she said 'kick'. Oops."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.240175",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "hny3JIDjR2Ks1BKmf1hGdQ",
+    "updated_at": "2020-01-05 13:42:23.240175",
+    "url": "https://api.chucknorris.io/jokes/hny3JIDjR2Ks1BKmf1hGdQ",
+    "value": "Chuck Norris once kicked a football into outer space and martians came down to return it."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.240175",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Z6du1qm7Q_WwbUPlhlr1Xw",
+    "updated_at": "2020-01-05 13:42:23.240175",
+    "url": "https://api.chucknorris.io/jokes/Z6du1qm7Q_WwbUPlhlr1Xw",
+    "value": "Chuck Norris has impregnated 73 women. Over the internet. They all died before the end of their first trimester from internal bleeding caused by roundhouse kicks. All babies survived."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.240175",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "k_Ib8LFYQcWSIPW2LT-Mrw",
+    "updated_at": "2020-01-05 13:42:23.240175",
+    "url": "https://api.chucknorris.io/jokes/k_Ib8LFYQcWSIPW2LT-Mrw",
+    "value": "Chuck Norris's Round House Kick causes particle accelaration."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.240175",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "YQBmTDVUQd-sVF578rV6mQ",
+    "updated_at": "2020-01-05 13:42:23.240175",
+    "url": "https://api.chucknorris.io/jokes/YQBmTDVUQd-sVF578rV6mQ",
+    "value": "When Freddy Krueger falls asleep , Chuck Norris appears to kick his ass!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.240175",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "tEcpBgEiRT6-7HDp_WaMHA",
+    "updated_at": "2020-01-05 13:42:23.240175",
+    "url": "https://api.chucknorris.io/jokes/tEcpBgEiRT6-7HDp_WaMHA",
+    "value": "Chuck Norris once roundhouse kicked a man with a merciful glancing blow to the forehead. And as a result, the man now has a fivehead."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.240175",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Dmrl5e0rTgOZGqhjWxyaVQ",
+    "updated_at": "2020-01-05 13:42:23.240175",
+    "url": "https://api.chucknorris.io/jokes/Dmrl5e0rTgOZGqhjWxyaVQ",
+    "value": "Chuck Norris inspired R.Kelly to write the song \"I Believe I Can Fly\" after he received a roundhouse kick that sent him flying to the moon."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.240175",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "L2DKUIjrQD2Iom5ownzDRA",
+    "updated_at": "2020-01-05 13:42:23.240175",
+    "url": "https://api.chucknorris.io/jokes/L2DKUIjrQD2Iom5ownzDRA",
+    "value": "Once a cow challenged Chuck Norris that he could not eat grass. Chuck Norris grazed 1/5 of the African continent in a day, which resulted in the formation of the Sahara desert. Then he proceeded to roundhouse kick and eat the cow at the same time. Moral of the story: Do not challenge Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.240175",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "t13aj2VSTr6F2FiuzDYlbg",
+    "updated_at": "2020-01-05 13:42:23.240175",
+    "url": "https://api.chucknorris.io/jokes/t13aj2VSTr6F2FiuzDYlbg",
+    "value": "Chuck Norris knows exactly how many roundhouse kicks to your ass that it takes to make a poignant hemorrhoidal bouquet for you...one!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.240175",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "NpsRQxZYSxydgZubjoeqIQ",
+    "updated_at": "2020-01-05 13:42:23.240175",
+    "url": "https://api.chucknorris.io/jokes/NpsRQxZYSxydgZubjoeqIQ",
+    "value": "Chuck Norris' pet hamster can kick a pit bulls ass."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.240175",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "QbAbT3ZHQlySm31MhlDelg",
+    "updated_at": "2020-01-05 13:42:23.240175",
+    "url": "https://api.chucknorris.io/jokes/QbAbT3ZHQlySm31MhlDelg",
+    "value": "Gary Neville can kick a football 200meters, to out do Garry Chuck Norris kicked phill Neville 300 meters"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.240175",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Ph9ICL6STruLd8du_d-HBQ",
+    "updated_at": "2020-01-05 13:42:23.240175",
+    "url": "https://api.chucknorris.io/jokes/Ph9ICL6STruLd8du_d-HBQ",
+    "value": "Chuck Norris has delivered enough roundhouse kicks to the ass to know just how many of them it takes to make a bountiful bouquet of hemorrhoids."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.240175",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "PimWVaFKTDG9bhjnERGKKw",
+    "updated_at": "2020-01-05 13:42:23.240175",
+    "url": "https://api.chucknorris.io/jokes/PimWVaFKTDG9bhjnERGKKw",
+    "value": "The danger of death sign is not a warning that you will get an electric shock that kills you, its a warning that Chuck Norris Roundhouse kicked somebody there."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.240175",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Dt2OwL_jTQyalijcyIuwBg",
+    "updated_at": "2020-01-05 13:42:23.240175",
+    "url": "https://api.chucknorris.io/jokes/Dt2OwL_jTQyalijcyIuwBg",
+    "value": "Chuck Norris once used the Grim Reaper as a Sherper up Everest but Roundhouse kicked him in the Death Zone and summitted ALONE"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "HOKETRqNQEiPwnvtIUSA5g",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/HOKETRqNQEiPwnvtIUSA5g",
+    "value": "Chuck Norris has never been accused of murder for the simple fact that his roundhouse kicks are recognized world-wide as \"acts of God.\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "nvdxPp5BQK2iQWRbPxrHVg",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/nvdxPp5BQK2iQWRbPxrHVg",
+    "value": "Chuck Norris died once. when greated by the grim reaper chuck proceded 2 round house kick the reaper.long story short death will never make that mistake again"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "FfLqGko-RV6EFzxIoP33jQ",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/FfLqGko-RV6EFzxIoP33jQ",
+    "value": "Chuck Norris once roundhouse kicked a hole into a cow, just to see what was coming down the road."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "cPOKN-OJSjCNvVXSxuWHiA",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/cPOKN-OJSjCNvVXSxuWHiA",
+    "value": "In his high school year book, Chuck Norris was named \" most likely to kick you in the face \"."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "4zEyJW-jQiWKDPfgZyDpAw",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/4zEyJW-jQiWKDPfgZyDpAw",
+    "value": "Chuck Norris was asked to donate blood. He proceed to donate 6 quarts... Simply by roundhouse kicking the flabotomist."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "6M53wgo7RkicbTpCNfw0Jw",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/6M53wgo7RkicbTpCNfw0Jw",
+    "value": "Chuck Norris can kick his way out of a black hole's Schwartzchild radius."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "vjqxAVZkQrKy8GOLh9OShQ",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/vjqxAVZkQrKy8GOLh9OShQ",
+    "value": "A man once told Chuck Norris that he and everyone would be wise to learn to \"expect the unexpected\" in life's journey. Chuck Norris then immediately roundhouse kicked the man in the face and said, \"did you expect that?\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "PbE7cRZ5RXGCeGB1VuUdjA",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/PbE7cRZ5RXGCeGB1VuUdjA",
+    "value": "Chuck Norris once kicked Doyle Brunson's ace."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "LJatOwobSgiVd57y3Scj_g",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/LJatOwobSgiVd57y3Scj_g",
+    "value": "When Chuck Norris was 9 he was out trick or treating and ran into Freddy Kruger. Chuck kicked the crap out of Freddy then took his candy."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Yytxg7Y4Q12o2PqSN3xXeg",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/Yytxg7Y4Q12o2PqSN3xXeg",
+    "value": "If Chuck Norris had a penny for each roundhouse kick he delivered, the world supply of iron would have been long gone."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "FKjcTbgAT5eyxwooaWx6Uw",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/FKjcTbgAT5eyxwooaWx6Uw",
+    "value": "Chuck Norris roundhouse kicked all the American out of Johnny Depp."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "eOcHK252SCmv6T5MsJiexA",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/eOcHK252SCmv6T5MsJiexA",
+    "value": "Why did Chuck Norris hasn't appeared on any mortal kombat games. Simple, the name says it all. \"mortal\". Also there won't be any fatality tha will work on him, he will just roundhouse kick anyone either he wins or loose."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "wqMuuH9yQBK3BF83RgLqPA",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/wqMuuH9yQBK3BF83RgLqPA",
+    "value": "Chuck Norris roundhouse kicked all the masculinity out of Justin Bieber, which all landed inside P!nk."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "fsTXH7kWSKesejuoIb5g5A",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/fsTXH7kWSKesejuoIb5g5A",
+    "value": "One day Chuck Norris roundhouse kicked a building killing thousands of while drinking a diet coke on a sunny day."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "x62RlLcTRP2DXTgJk3ol9w",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/x62RlLcTRP2DXTgJk3ol9w",
+    "value": "Chuck Norris shot the sheriff, killed Kenny, and killed Mr. Boddy in the hall with a roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "uWIZNxwIREymjuSX7Xg_fA",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/uWIZNxwIREymjuSX7Xg_fA",
+    "value": "Zebras were created when Chuck Norris kicked the color out of horses."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "pCgZ_c8XRzO9U9W9tD_48w",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/pCgZ_c8XRzO9U9W9tD_48w",
+    "value": "Chuck Norris went to court once, and he lost. He roundhouse kicked the judge in the head so hard that all of justice became blind."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "xAKQ4jaQT7i_Br4Eq1nLVQ",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/xAKQ4jaQT7i_Br4Eq1nLVQ",
+    "value": "Chuck Norris gave Santa Claus a present on December 25, 2012. The present turned out to be a small box that contained 100% exact, invincible, and miniature clones of everything that ever existed and will exist. Well, the clone of Chuck Norris wasn't accurate, as its roundhouse kick could not kill anything stronger than an African elephant due to how small it was, but that was the only exception."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "BYFfJUaMShqPyWpFLph8AQ",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/BYFfJUaMShqPyWpFLph8AQ",
+    "value": "The reason Chuck Norris's shoes are brown is because the shit from peoples ass is caked onto his shoes from kicking their ass that hard."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.484083",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "1lqKdidUTLu1pEl4Oow7MA",
+    "updated_at": "2020-01-05 13:42:23.484083",
+    "url": "https://api.chucknorris.io/jokes/1lqKdidUTLu1pEl4Oow7MA",
+    "value": "When Chuck Norris wants something, the person standing next to him better goddamn give it to him within the next two seconds or die by the roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "TAzGfQUvRImy7Oo0jf5_ew",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/TAzGfQUvRImy7Oo0jf5_ew",
+    "value": "Mr. T threw a punch and Chuck Norris met his punch with a round house kick....... The result was the 80's."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Yke6bi5xSdWvSq_dkCCGkA",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/Yke6bi5xSdWvSq_dkCCGkA",
+    "value": "Chuck Norris can roundhouse-kick you in the face so hard, archaeologists from thousands of years from now will find your skull fragments in the next continent encrusted with diamonds."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "00NuSNToRkm7YZ6nvjdhlg",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/00NuSNToRkm7YZ6nvjdhlg",
+    "value": "I got an e-roundhouse kick from Chuck Norris. My cheeks are still swollen."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ORkyhj4OR2K2XMRVjtFarg",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/ORkyhj4OR2K2XMRVjtFarg",
+    "value": "When you die, Chuck Norris will find your grave and roundhouse kick you."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "BHyzMEESRqefeRskfTZ6Ig",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/BHyzMEESRqefeRskfTZ6Ig",
+    "value": "Chuck e cheese was actually gonna be called: Chuck Norris cheese. it was then changed for being too violent. Every animatronic for Chuck Norris cheese was violent because they do roundhouse kicks."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "8u3AJB0wTH6o-PPoMjww2A",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/8u3AJB0wTH6o-PPoMjww2A",
+    "value": "Chuck Norris once grabbed Vin Diesel and inserted his index finger into Vin Diesel's anus. Vin Diesel got very pissed over the matter. Chuck Norris then started kicking him continously non-stop for a day for not having any sense of humor."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "QZBtgeNIQEOT0YD7gP6jBA",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/QZBtgeNIQEOT0YD7gP6jBA",
+    "value": "They say Bruce Lee died in an accident...but it is the fact you don't kick Chuck Norris' ass without consequence!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "D4OpidSyTZ-egL_f_0XPSg",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/D4OpidSyTZ-egL_f_0XPSg",
+    "value": "Chuck Norris invented the word 'oblivion' so his roundhouse victums would have a place to find themselves kicked into."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "yHsnDQYWQLyaZGjflCWE9g",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/yHsnDQYWQLyaZGjflCWE9g",
+    "value": "The number on tombstones aren't years; there just how many times Chuck Norris roundhouse kicked that person in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "n3Lo6xzmQEG84GX7_DttwQ",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/n3Lo6xzmQEG84GX7_DttwQ",
+    "value": "Chuck Norris once kicked a foot ball so hard it went into orbit and took out the command ship of an alien armada that where plotting to take over the earth ... they soon changed there minds"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "GUvQNdjLSRSl6yrl6ifApg",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/GUvQNdjLSRSl6yrl6ifApg",
+    "value": "Q. Can you spell \"Chuck Norris\" without using any r's? A. Yes, \"Chuck Kickass\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "9O7seT6CQXOahpAqHuDUvA",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/9O7seT6CQXOahpAqHuDUvA",
+    "value": "If Chuck Norris had a pennie for every time he roundhouse kicked someone, he would be the richest man ever."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "n0it85Y-Sae48n7AWnJSOA",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/n0it85Y-Sae48n7AWnJSOA",
+    "value": "Davy Crockett shot his first bear when he was only 3. Chuck Norris roundhouse kicked his first bear into oblivion when he was only 6 months old."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "h1MN_q9sT3aWTH9PBZJTCg",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/h1MN_q9sT3aWTH9PBZJTCg",
+    "value": "Chuck Norris created the alphabet just so he could spell the words \"kicked your ass\"."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "6OhqDMjzQOqz006M-nIErA",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/6OhqDMjzQOqz006M-nIErA",
+    "value": "When you tell Chuck Norris a Chuck Norris fact, he laughs. And then roundhouse kicks you in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "TQAVUA4YTyGkNaw2sjHhxA",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/TQAVUA4YTyGkNaw2sjHhxA",
+    "value": "For the extra added kick to his homemade Texas Chili, Chuck Norris adds a 1/2 cup of Y.pestis infected rat turds as seasoning."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Obi8Vp_uRXqrjmMgjrCPaw",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/Obi8Vp_uRXqrjmMgjrCPaw",
+    "value": "Gregg Valentino is known to have the biggest biceps on the planet. That's because he once accidentally dropped a weight on Chuck Norris foot while training in the gym with Chuck. That action Caused Chuck's reflex's to hammer-kick Valentino in each bicep. Now even Arnold is amazed at Valentino's giant swollen biceps."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "DF5ewSDZSgWPNz-XsEv3KA",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/DF5ewSDZSgWPNz-XsEv3KA",
+    "value": "If you ask Chuck Norris what time it is, he'll answer 'Two seconds 'till...' When you ask him 'Two seconds 'till what?', that's when he roundhouse kicks you in the face"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "s56YoYPmRgOMZM4-I9AclQ",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/s56YoYPmRgOMZM4-I9AclQ",
+    "value": "Sauron's ring was actually Chuck Norris', and if he'd known he'd of kicked Frodo's arse."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "OKcb-bcxQjaRlMzQLSSypg",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/OKcb-bcxQjaRlMzQLSSypg",
+    "value": "Jack was nimble, Jack was quick, but Jack still couldn't dodge Chuck Norris' roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "R55uzYlySNGawd5gdctDvw",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/R55uzYlySNGawd5gdctDvw",
+    "value": "Four score and seven years ago... Chuck Norris drank a barrel of mead and roundhouse kicked the shit outta some mutton chop-wearing assholes."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "dBSTXZ9UTTGR9QsWdfbHqQ",
+    "updated_at": "2020-01-05 13:42:23.880601",
+    "url": "https://api.chucknorris.io/jokes/dBSTXZ9UTTGR9QsWdfbHqQ",
+    "value": "Chuck Norris will be roundhouse kicking your ass in a second. And then he does mine."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ZPjKsBDiRiyRMY3356hD7w",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/ZPjKsBDiRiyRMY3356hD7w",
+    "value": "Chuck Norris once roundhouse house kicked a man for asking him who invented the Roundhouse Kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "LohSg2a0RfisY4Lk5I5ZLQ",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/LohSg2a0RfisY4Lk5I5ZLQ",
+    "value": "Chuck Norris can roundhouse kick you in such a way that you become incapable of dying, and just do a little worse every day."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ztULFv21SDyoWxeD3gxUhw",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/ztULFv21SDyoWxeD3gxUhw",
+    "value": "When you ask Chuck Norris for directions, he'll give you a roundhouse-kick to the face and you'll land exactly where you need to be."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "eSMKOpX-SMKc1imLH0ukow",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/eSMKOpX-SMKc1imLH0ukow",
+    "value": "Chuck Norris' roundhouse kick is an illusion. His right foot doesn't kick you. His left foot spins the Earth so that your head hits his foot."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "dkauV66LRmWo-ZeTRXe1nw",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/dkauV66LRmWo-ZeTRXe1nw",
+    "value": "Chuck Norris can literally hand you your ass in a handbag. And then pull it out and kick it up between your ears."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "L6Tetv2BRpqLHUlllPg6wQ",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/L6Tetv2BRpqLHUlllPg6wQ",
+    "value": "All people with hemorrhoids have been the recipient of a Chuck Norris roundhose kick to the mouth that was delivered so severely that it caused their tounge, tonsils and adenoids to protrude from their asshole."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "H_8HHgPYT82RckUqJaIiYQ",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/H_8HHgPYT82RckUqJaIiYQ",
+    "value": "Chuck Norris was at a rap concert once and the rapper told everyone to raise the roof. Promptly afterward he killed the rapper with a swift roundhouse kick to the face. No one tells Chuck Norris what to do."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "LkCUKcLDTFaMWGEf1tg0zg",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/LkCUKcLDTFaMWGEf1tg0zg",
+    "value": "On June 7th 1994, Chuck Norris entered the same restaurant supermodel Cindy Crawford was eating at. Instinctively, Cindy swept everything off the table, threw herself on it in a fit of lust, and begged Chuck to ravish her. After Chuck finished his beer, he obliged her. When Chuck's magnificent lead sperm cannoned into Cindy's womb it went straight to one of her ovaries and roared, \"Which one of you servile wenches thinks you can handle getting split open by the Chuck!?\" All of the eggs cowered in the corner. The same thing happened at the other ovary. \"I didn't fucking think so!\" shouted the lead sperm which then lead the rest of the troops back into Chuck's balls. Chuck pulled out; roundhouse kicked Cindy in the face and told her, \"Don't ever waste my time again.\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "9L8igzTRTHGEeb1wfye_GA",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/9L8igzTRTHGEeb1wfye_GA",
+    "value": "If you look up the term Ass Kicker in the dictionary, there will be a picture of nothing--because it's a fucking dictionary, they don't have pictures--but the page will smell a little bit like Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "R0kKsATWTmOxMHjGs_wpEA",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/R0kKsATWTmOxMHjGs_wpEA",
+    "value": "Contrary to the popular idiom, it was in fact a Chuck Norris flying roundhouse kick and not a straw that broke the camel's back."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "xDKhh1k3T_qiQEnRTyeklg",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/xDKhh1k3T_qiQEnRTyeklg",
+    "value": "Steven Segal onece challenged Chuck Norris to a fight, Chuck Norris roundhouse kicked him in the face. this is why Steven Segal talks funny"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "KCm7Zq7LRhmk5LzsfHyUbw",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/KCm7Zq7LRhmk5LzsfHyUbw",
+    "value": "Chuck Norris is Death of the Four Horsemen of the Apocalypse. He kills by the grace of the roundhouse kick, and he rides a bull. The others dare not question him."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "AgYSgmK6Ry2GSVzr9T4vPQ",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/AgYSgmK6Ry2GSVzr9T4vPQ",
+    "value": "Chuck Norris's poster once kicked my ass and put me in the Hospital for a year."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "U0UXcYV-SBqAZLPY8edqpg",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/U0UXcYV-SBqAZLPY8edqpg",
+    "value": "I assure you, the great day of the kicking will occur. By this I mean that actor Chuck Norris will literally pull up in your yard in his Hummer, walk to your front door, wait for you to open it, then kick you in the face before straightening his jacket and calmly driving away. The day is coming."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "BLzsX8RrS-iVGuJCXgNHtQ",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/BLzsX8RrS-iVGuJCXgNHtQ",
+    "value": "Chuck Norris thinks outside the box,then roundhouse kicks the box into oblivion."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "1JrQrY71QK-4lZmqOtzU1A",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/1JrQrY71QK-4lZmqOtzU1A",
+    "value": "When Chuck Norris went to Oz he had a field day kicking Munchkin @$$; they covered up the blood trails left on the roads with yellow paint."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "TE4kJMysTpKcMOm4wu5rEw",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/TE4kJMysTpKcMOm4wu5rEw",
+    "value": "Meteors are actually people blazing down to Earth after having been roundhouse kicked by Chuck Norris into space for telling bad jokes about him."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "tsueglACSTWNv1rBeSEN-Q",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/tsueglACSTWNv1rBeSEN-Q",
+    "value": "Chuck Norris put humpty dumpty back together again, only to roundhouse kick him in the face"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "2ii9LHvGTr6dsFqF3Qcvuw",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/2ii9LHvGTr6dsFqF3Qcvuw",
+    "value": "Chuck Norris is the only person who can eMail a roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "htZ0q3mBSQyrvRxLrvxlNA",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/htZ0q3mBSQyrvRxLrvxlNA",
+    "value": "Bruce Lee died from a delayed reaction to a Chuck Norris roundhouse kick to the face in Way of the Dragon."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.142371",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "8uqZm9dvShSoZ9XjQuV9jQ",
+    "updated_at": "2020-01-05 13:42:24.142371",
+    "url": "https://api.chucknorris.io/jokes/8uqZm9dvShSoZ9XjQuV9jQ",
+    "value": "If you look up Chuck Norris in the dictionary, you will get Round house Kicked in the face, or the balls, depending on how you are holding the dictionary."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "VHzcKLMITl6QsRaayC34TQ",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/VHzcKLMITl6QsRaayC34TQ",
+    "value": "A Jehovah witness once knocked on Chuck Norris door. Chuck Norris let the Jehovah witness into the house and then roundhouse kicked him out the window. The man tried to sue Chuck Norris for assault but could not prove anything since there was no witnesses."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ITSvovDyQg-fnhgGnBlJlA",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/ITSvovDyQg-fnhgGnBlJlA",
+    "value": "Lightning is like a Chuck Norris roundhouse kick in the face. In a flash it's gone. Both lightning & your face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "b4bijS1BQ9uyONWV67W7DA",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/b4bijS1BQ9uyONWV67W7DA",
+    "value": "Chuck Norris was challenged to a fight by the high school bully, so Chuck proceeded to kick the crap out of him. Chuck was in the fifth grade at the time."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "B1Rz0sqqT3a7sP2I71eXhg",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/B1Rz0sqqT3a7sP2I71eXhg",
+    "value": "Chuck Norris round-house kicked micheal jackson and he turned from black to white"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "J8JwOIAVR0m1og4j4HQZ4A",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/J8JwOIAVR0m1og4j4HQZ4A",
+    "value": "Chuck Norris was the original star for the movie Pacific Rim. The director had to fire Chuck when he continued to single handedly kick the shit out of the Kijus."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "QxCSyCDZSaqlLTuQBowhmw",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/QxCSyCDZSaqlLTuQBowhmw",
+    "value": "Chuck Norris can kill a red dragon with his level 1 mage using a single magic missile.. immediately followed by a roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "mfzv5aifS-qtrE2TqmQaYQ",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/mfzv5aifS-qtrE2TqmQaYQ",
+    "value": "Once Chuck Norris died just to see how it feels like to be dead. The next day he resurrected himself and roundhouse kicked everyone who celebrated his temporary death."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "hiBPrzzDQtG1boAZ2eJ6JA",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/hiBPrzzDQtG1boAZ2eJ6JA",
+    "value": "If Chuck Norris roundhouse kick Bruce banner he would not get angry, he would be cured and never again will transform in the hulk, cause Chuck Norris kicks have healing properties. Either you get cured or die"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "2r8BMA41TTOQ_XZvdOCo1A",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/2r8BMA41TTOQ_XZvdOCo1A",
+    "value": "If Chuck Norris really likes you, he can make a single roundhouse kick last five hours."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "fqdYQm-ySaCoWUXrzfVBzQ",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/fqdYQm-ySaCoWUXrzfVBzQ",
+    "value": "Chuck Norris has a job. His job is to roundhouse kick people. He gets a million dollars if he does. then hes done."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Afs59AUXTzWQepoCo63QZw",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/Afs59AUXTzWQepoCo63QZw",
+    "value": "The U.S. Military once tried to capture the power of a round house kick from Chuck Norris into a bomb. It was called the Manhattan Project and it didn't even come close."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "WHXgQ1y4TD2HzspJYUKpIA",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/WHXgQ1y4TD2HzspJYUKpIA",
+    "value": "While playing Rock Band, Chuck Norris can play air drums and still hit the notes. Going into overdrive without telling him, he instantly gives you a round house kick to the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "a2xnpeWYQXiWoUBfaBHITQ",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/a2xnpeWYQXiWoUBfaBHITQ",
+    "value": "Chuck Norris once roundhouse kicked a black person so hard he turned white"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "GgZFbC9CSOyUBiw41Iji4g",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/GgZFbC9CSOyUBiw41Iji4g",
+    "value": "Chuck Norris discovered a new theory of relativity involving multiple universes in which Chuck Norris is even more badass than in this one. When it was discovered by Albert Einstein and made public, Chuck Norris roundhouse-kicked him in the face. We know Albert Einstein today as Stephen Hawking."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "0pVT7H3gSz6dC1Uj3mQquw",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/0pVT7H3gSz6dC1Uj3mQquw",
+    "value": "In back to the future 4 Chuck Norris roundhouse kicked the Delorean back. This also gave Micheal J Fox Parkinson's."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "-tcMhGBVSYqiAThUP3FYVw",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/-tcMhGBVSYqiAThUP3FYVw",
+    "value": "Chuck Norris has a hemorrhoid the size of a bowling ball. He's been so busy kicking ass that hasn't even noticed it yet."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "OHXHN2LwS_qDSe0klSMtKg",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/OHXHN2LwS_qDSe0klSMtKg",
+    "value": "Chuck Norris was never born. he roundhouse kicked his way out of his mothers whom and proceded on kicking the rest of the doctors to."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "YpuqnPImSuucUI7lJiCpnw",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/YpuqnPImSuucUI7lJiCpnw",
+    "value": "When Chuck Norris asks you a question he doesn't need an answer coz he already knows and when you try to answer he will roundhouse kick you and ask you again and when you dont answer he will round house kick you again and ask you another question...... remember Chuck Norris counted to infinity twice"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "B9teOdrMQuGM9YMKBB5JJQ",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/B9teOdrMQuGM9YMKBB5JJQ",
+    "value": "A married couple went to Chuck Norris for their relationship problems. The husband said, \"Oh great and powerful Chuck Norris, my wife has lost the ability to feel pleasure in bed! What can I do to fix this?\" Chuck Norris then proceeded to make love to the guy's wife right on the floor next to him. After about three and a half hours of her moaning in ecstasy and epic music, Chuck Norris got up and said, \"She seems to be working alright for me!\" He then roundhouse kicked them both into space, thus ending the couples relationship problems forever!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "PLwK9wWgR525DB5AFhmtiA",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/PLwK9wWgR525DB5AFhmtiA",
+    "value": "The Grim Reaper looked at Chuck Norris and was pantsed and round house kicked in the balls, at the same time a new born child was named: Chuck Alfred Norris Tomas, and died instantly."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.40636",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Tv8HGIlHSRGYBmt6J9e8Cw",
+    "updated_at": "2020-01-05 13:42:24.40636",
+    "url": "https://api.chucknorris.io/jokes/Tv8HGIlHSRGYBmt6J9e8Cw",
+    "value": "When Chuck Norris was younger, he wore cowboy boots, had a red beard and could deliver a fatal roundhouse kick. Knowing this one could imply that Chuck Norris has always been awesome."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "mPtSFMcfQuqwXo8NJtfRkA",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/mPtSFMcfQuqwXo8NJtfRkA",
+    "value": "Chuck Norris can literally kick a person's ass into next week. Their head will travel five days farther."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "DjtJspggRgqFVgo6AHBVPA",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/DjtJspggRgqFVgo6AHBVPA",
+    "value": "Knock knock. Whos there? Chuck Norris. Chuck Norris who? Chuck Norris is gonna roundhouse kick ya in the FACE"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Eph-7ARcTeanoYhzAo7U6w",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/Eph-7ARcTeanoYhzAo7U6w",
+    "value": "One day a man waves to Chuck Norris. Chuck Norris got mad and roundhouse kicked him in the face today we know him know as the elephant man."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "MLm5jlTDTXW40ajYL1-bGA",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/MLm5jlTDTXW40ajYL1-bGA",
+    "value": "Chuck Norris can knock you down with a feather. But he prefers a savage roundhouse kick to the brain."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "fKuYuPBFQZaOCFinwassFQ",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/fKuYuPBFQZaOCFinwassFQ",
+    "value": "Chuck Norris has a roundhouse-kick app for his iPhone &#8734;.0"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "8jLJNGw-QSWsfXZffHV2-A",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/8jLJNGw-QSWsfXZffHV2-A",
+    "value": "NO ALISTER CHUCK NORRIS KICKS YO ASS :), NO ALISTER CHUCK NORRIS KICKS YO ASS :), NO ALISTER CHUCK NORRIS KICKS YO ASS :), NO ALISTER CHUCK NORRIS KICKS YO ASS :), NO ALISTER CHUCK NORRIS KICKS YO ASS :), NO ALISTER CHUCK NORRIS KICKS YO ASS :), NO ALISTER CHUCK NORRIS KICKS YO ASS :), NO ALISTER CHUCK NORRIS KICKS YO ASS :),"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "2X-S5CnYQwOd7f2vejFHOA",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/2X-S5CnYQwOd7f2vejFHOA",
+    "value": "It is possible to look to the left and right at the same time with just a roundhouse kick from Chuck Norris"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "h43Kev_3S4-5L9M1KkmLdQ",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/h43Kev_3S4-5L9M1KkmLdQ",
+    "value": "A man once told Chuck Norris that he would like to go to Mars. Chuck Norris then bent the man over backwards, shoved the man's head up his own ass and then asked, \"Do you want an express or first class flight?\" The man said, \"mumble mumble.\" Then Chuck Norris roundhouse kicked him to Jupiter. This is because Chuck Norris doesn't know the names of the planets, nor does he give a shit about them."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gQgNYb2xTBWmHGdjTNQ8gg",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/gQgNYb2xTBWmHGdjTNQ8gg",
+    "value": "Chuck Norris doesn't use keys, he always kicks the door in."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "MV3qii6PTj2pvFtth6h5RA",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/MV3qii6PTj2pvFtth6h5RA",
+    "value": "Chuck Norris created Canada when he kicked all the Liberals out of America."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "PtHWEpXXRHmkCbm54BrEXA",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/PtHWEpXXRHmkCbm54BrEXA",
+    "value": "When Chuck Norris wants bacon, he roundhouse kicks a pig until it is dead."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "fJa5d9-MQCGP7TpwvjpiPQ",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/fJa5d9-MQCGP7TpwvjpiPQ",
+    "value": "The first roundhouse kick of Chuck Norris made Pangaea turn into six different continents, THEN he decided which was the North and South"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "wAkLSmHRS9O_f7bfP8TYCQ",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/wAkLSmHRS9O_f7bfP8TYCQ",
+    "value": "Chuck Norris was once in a catch 22, but he roundhouse kicked it down to a 12 pack and literally drank his problems away."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "XRJre4oESZuWvqM2408vdw",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/XRJre4oESZuWvqM2408vdw",
+    "value": "Everytime you jack off, Chuck Norris roundhouse kicks a mexican baby."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ZMiPZGt_StuQJ05y44gcVA",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/ZMiPZGt_StuQJ05y44gcVA",
+    "value": "*Chuck Norris is an acronym, it means: Crushing Heads Under Cars and Kicking Ninjas Over Rail Roads and Into Space"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "mKvP-3adTHSM-iDjxl1JgQ",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/mKvP-3adTHSM-iDjxl1JgQ",
+    "value": "Chuck Norris turned up at Buckingham Palace for his knighthood seven hours late and reeking of alcohol and pussy, and wearing only a flak jacket and christmas lights. When the queen touched his shoulder with a sword, he instinctively roundhouse kicked her."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "_nqSKoD0TvmvBYF_PqiKRg",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/_nqSKoD0TvmvBYF_PqiKRg",
+    "value": "Chuck Norris does not believe in discrimination based on sex, age, race, religion, culture or geography - when it comes to his roundhouse kicks."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "9gnFAm4uQZ2mGnDpWFb0Ag",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/9gnFAm4uQZ2mGnDpWFb0Ag",
+    "value": "What is the definition of infinity? The number of people Chuck Norris has roundhouse kicked in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "OTNBYiMZTZyw7CH98u8Qng",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/OTNBYiMZTZyw7CH98u8Qng",
+    "value": "Chuck Norris getting his ass kicked is as likely as seeing a vampire with a suntan."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "liEwxoFtRd-UKVFg_oqqrQ",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/liEwxoFtRd-UKVFg_oqqrQ",
+    "value": "Homeless people are afraid to ask Chuck Norris for change. The last guy who did got a half dollar scissor kicked up his ass...twice."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "adV0YmpNTtugDOMSC2Xhew",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/adV0YmpNTtugDOMSC2Xhew",
+    "value": "Chuck Norris once roundhouse kicked a salesman over the telephone."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "7w5sd_KSTgGwsVCQc3U8KA",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/7w5sd_KSTgGwsVCQc3U8KA",
+    "value": "Chuck Norris was origionally to be cast as Neo in The Matrix, but when they told him about the powers he would recieve, he laughed and said im Chuck Norris! He then proceeded to roundhouse kick the Warner Brother representatives and flying off to drink some beer and kick some random person's ass"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "AglEkdTcRde6JpgHXLaI4w",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/AglEkdTcRde6JpgHXLaI4w",
+    "value": "IF CHUCK NORRIS GIVES YOU A ROUND HOUSE KICK IN YOUR DREAMS YOU REALY DIE"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:24.696555",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "lLwVN6kmQLq6pnyBrm5lnw",
+    "updated_at": "2020-01-05 13:42:24.696555",
+    "url": "https://api.chucknorris.io/jokes/lLwVN6kmQLq6pnyBrm5lnw",
+    "value": "Chuck Norris and Cookie Monster once had a contest to see who ate the most cookies. At the end, Chuck Norris roundhouse kicked Cookie Monster in the head."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "qM6kcTkvTha6jNbFtnwnrw",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/qM6kcTkvTha6jNbFtnwnrw",
+    "value": "The Draught of Living Death is not a magical potion or anything like it, it's not even liquid. It's the state of a human which, by some hell of an accident, survived a Chuck Norris roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ek9Nok9aSPqwT-DcuSTAEA",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/ek9Nok9aSPqwT-DcuSTAEA",
+    "value": "Chuck Norris frequently signs up for beginner karate classes so he can accidentally roundhouse kick kids in the neck."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "1MYGljsGT3O7OduWGl-lRA",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/1MYGljsGT3O7OduWGl-lRA",
+    "value": "Buzz Lightyear found out just how far it is to infinity and beyond after Chuck Norris drop kicked his ass for refusing to come out of his grandson's toy box."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gbsDaP82RXy1okrGLW-EIg",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/gbsDaP82RXy1okrGLW-EIg",
+    "value": "Chuck Norris is known to jump out of televisions and roundhouse kick the viewers for no reason at all. Extreme caution is advised while watching any shows involving Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "fPKt-ZFBRPGilGw7ka5miQ",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/fPKt-ZFBRPGilGw7ka5miQ",
+    "value": "The comma was formed when Chuck Norris roundhouse kicked the fullstop which tried to make him stop his sentence. Needless to say, there are no fullstops in Chuck Norris' world."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "neFyjQqtSOWgRDj-EFz2Yw",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/neFyjQqtSOWgRDj-EFz2Yw",
+    "value": "I used to question Chuck Norris like you but then I took a roundhouse kick to the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "eC95mzOiQr2rRirtUPGZhg",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/eC95mzOiQr2rRirtUPGZhg",
+    "value": "If you ever dream of kicking Chuck Norris' ass, you will wake up to see him standing over you."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "DWTcF8dpStKZUNdBmU2L4w",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/DWTcF8dpStKZUNdBmU2L4w",
+    "value": "In high school, Chuck Norris would tape \"Kick Me\" signs on his own back in the hopes that someone would take the bait."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "BEj45LLAS1OnHedpm4CVig",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/BEj45LLAS1OnHedpm4CVig",
+    "value": "Chuck Norris is the only human being to display the Heisenberg uncertainty principle -- you can never know both exactly where and how quickly he will roundhouse-kick you in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "zywxkMVyRFmrG93_G2zJUA",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/zywxkMVyRFmrG93_G2zJUA",
+    "value": "Chuck Norris was told he needs to be more sensitive. Chuck said \"I am sensitive, the last guy that mouthed off to me got kicked in the nuts instead of the face\"."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "jNUDBty0SXuIk7pfoXomLQ",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/jNUDBty0SXuIk7pfoXomLQ",
+    "value": "Chuck Norris kicked the sparkles right off of Edward Cullen."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "6VD662gkTBGLYHqTW_zF6A",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/6VD662gkTBGLYHqTW_zF6A",
+    "value": "Too much love will NOT kill you, eevery time but a Chuck Norris roundhouse kick to the face will kill you. Eevery time."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "BPJ5A7DIRN6XYoax2Uz9Aw",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/BPJ5A7DIRN6XYoax2Uz9Aw",
+    "value": "A pair of Chuck Norris' jeans was recently put up for auction. The leg reflexively kicked three appraisers."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "FWIFCFVpTNuT9s7Kml6WhA",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/FWIFCFVpTNuT9s7Kml6WhA",
+    "value": "Chuck Norris went to church once... they kicked him out and told him he got an early acceptance into heaven"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Oub93C_uTlyRaGTVqBIWqQ",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/Oub93C_uTlyRaGTVqBIWqQ",
+    "value": "Chuck Norris killed Zeus in a poker game with a roundhouse kick to the face because Zeus was a sore loser and didn't want to give up his lightning."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "qEnWlsQIQ7q_j1Rl3m3kdg",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/qEnWlsQIQ7q_j1Rl3m3kdg",
+    "value": "Chuck Norris once sold his soul to the devil in exchange for the power of the roundhouse kick. After signing the contract, chuck quickly roundhouse kicked the devil in the face knocking him unconscious long enough to take his soul back. The devil, who appreciates irony, had a good laugh about it. Now they meet in Indiana every second Tuesday of the month to play poker"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Vitxm3PJRe68zprm5gVXrw",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/Vitxm3PJRe68zprm5gVXrw",
+    "value": "\"Everybody Hates Chris\" was originally called \"Chuck Norris Hates Chris\" but Chris Rock didn't want to make a series just about how he survive Chuck Norris round house kicking him EVERYDAY"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "1YeIdl3fQaKCi-z6iV63_Q",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/1YeIdl3fQaKCi-z6iV63_Q",
+    "value": "The leaning tower of Pisa used to stand up straight. That is..... until Chuck Norris roundhouse kicked it."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gcUDHW9xQCyZ3zTfLJp1yw",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/gcUDHW9xQCyZ3zTfLJp1yw",
+    "value": "The closest Chuck Norris has come to getting his ass kicked was when he gave himself a dirty look in the mirror."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gpIzeCklR8efCmSiwfzIZg",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/gpIzeCklR8efCmSiwfzIZg",
+    "value": "Chuck Norris roundhouse-kicked the acting ability out of Vin Diesel."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.099703",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gt41FVisSvG42v-p3yd3HQ",
+    "updated_at": "2020-01-05 13:42:25.099703",
+    "url": "https://api.chucknorris.io/jokes/gt41FVisSvG42v-p3yd3HQ",
+    "value": "Chuck Norris can roundhouse kick a window pane with such infinite presicion that only one side of it breaks."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "v-WHiUjnSnOkATCbRyjZrA",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/v-WHiUjnSnOkATCbRyjZrA",
+    "value": "Chuck Norris doesn't give a fuck if the glass is half empty or half full. He's still gonna round house kick you in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "5zrFJKg6RqyyU1jsqIL8Tg",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/5zrFJKg6RqyyU1jsqIL8Tg",
+    "value": "There is a Chuck Norris fact number zero, but those who read it will get blind because that was Chuck Norrir's first fact, created from Chuck Norris's Round House Kicks."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "CzoEfJ6WSqCpgdO6VTQrpw",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/CzoEfJ6WSqCpgdO6VTQrpw",
+    "value": "Chuck Norris originally appeared in the \"Street Fighter II\" video game, but was removed by Beta Testers because every button caused him to do a roundhouse kick. When asked bout this \"glitch,\" Norris replied, \"That's no glitch.\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "sVfOLkVJRwOFkxtUGFy6Aw",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/sVfOLkVJRwOFkxtUGFy6Aw",
+    "value": "The big bang did not create the universe Chuck Norris did with one roundhouse kick"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "a2rcp1fmRZWQPpP02b6yJA",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/a2rcp1fmRZWQPpP02b6yJA",
+    "value": "Chuck Norris always give more bang for your buck. In other words, he will roundhouse kick you in the face, then take your wallet."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "uvuwkhl_SEi0TpC1-hIwMA",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/uvuwkhl_SEi0TpC1-hIwMA",
+    "value": "The Marquis de Sade invented wrought iron testicle clamps. Chuck Norris univented them which is why you've never heard of them before. Chuck Norris prefers to destroy your balls with a roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gHfuzPFmTFaXyBKW8f1WIw",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/gHfuzPFmTFaXyBKW8f1WIw",
+    "value": "Chuck Norris is an unlockable Character on the new MK9.To unlock:beat game on hardest difficulty by only using roundhouse kicks, fatality all characters with roundhouse kick.when he shows up for the fight hold the run button hoping you can outrun him."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "HJzA3JzQQuKXbjcz0gyURg",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/HJzA3JzQQuKXbjcz0gyURg",
+    "value": "The film Hellbound is actually a documentary. Satan has, in fact, been dead since 1994, when Chuck Norris roundhouse kicked him."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "amuiE9JxT-66CTvrnGLQlg",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/amuiE9JxT-66CTvrnGLQlg",
+    "value": "Chuck Norris likes to drop kick nuns at the full moon. The craters are direct hits."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "4XpBg1qRRuyKopwmUsVxrg",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/4XpBg1qRRuyKopwmUsVxrg",
+    "value": "Chuck Norris was once paralyzed by the pressure of his awesomeness. He then roundhouse kicked his awesomeness to Mars, where it eradicated all life, he then made more awesome."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Pe2_FjtCRqm9DBse6FQxkg",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/Pe2_FjtCRqm9DBse6FQxkg",
+    "value": "One time the Enterprise needed to exceed warp 9 speed, so Chuck Norris round house kicked it. The Enterprise warped out of existence."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "cgcBXiu_SZyAX94jjqEUiw",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/cgcBXiu_SZyAX94jjqEUiw",
+    "value": "When I found out about this site, I roundhouse kicked it so hard it suddenly got a link to the Hugh Jackman fact generator. Nice guy. I went fishing with him once. Then I kicked his ass. Because I'm f***ing Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "4AuzH_1_TYqZhXU1S-IaLg",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/4AuzH_1_TYqZhXU1S-IaLg",
+    "value": "Chuck Norris can run faster than the speed of light and kick light in its ass and send it flying even faster than the speed of light, and then run faster than the new speed of light and again do the same over and over again. Every time he does it new universes are created."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "aBijsx0zQyqAsGq9d9Rq-g",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/aBijsx0zQyqAsGq9d9Rq-g",
+    "value": "Chuck Norris does not navigate through a corn maze... The corn merely realigns itself in chucks favor out of fear of being roundhouse kicked in the ears!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "CHO5LQ4pS2OiWooS3LNxXg",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/CHO5LQ4pS2OiWooS3LNxXg",
+    "value": "Doctors have discovered that a Chuck Norris roundhouse kick would cure every disease known to man. However, since it would also shatter your bones and vital organs, it has never been implemented."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "3RiKtc-ESnmZsHab5aSZFw",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/3RiKtc-ESnmZsHab5aSZFw",
+    "value": "Just simply witnessing a Chuck Norris roundhouse kick to somebody else's face can cause you to get a case of Tourette's syndrone."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "fkqegKXjSISVhH1ao_FmwA",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/fkqegKXjSISVhH1ao_FmwA",
+    "value": "Scientists use Chuck Norris' spectacular kicks to calibrate their earthquake warning systems"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "C6Rcnt5ZRASpeAClhrFZ4g",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/C6Rcnt5ZRASpeAClhrFZ4g",
+    "value": "Chuck Norris was breifly considered for the next Batman movie, but after test shoots, it became clear that it's impossible to film the batroundhouse kick and survive."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "2Aq3NvEFRICJhS7jESKgng",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/2Aq3NvEFRICJhS7jESKgng",
+    "value": "Can Chuck Norris kick it? Of course he fucking can."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.352697",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "9T0Isn9CSu6YsJqFYqRkgQ",
+    "updated_at": "2020-01-05 13:42:25.352697",
+    "url": "https://api.chucknorris.io/jokes/9T0Isn9CSu6YsJqFYqRkgQ",
+    "value": "Chuck Norris can give you a vasectomy with a roundhouse kick or a trombone...your choice?"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.628594",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "i3nbcxjAQ_e6zibp6nZZTw",
+    "updated_at": "2020-01-05 13:42:25.628594",
+    "url": "https://api.chucknorris.io/jokes/i3nbcxjAQ_e6zibp6nZZTw",
+    "value": "China was once bordering the United States, until Chuck Norris roundhouse kicked it all the way through the Earth."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.628594",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "VK-7RRBMR4mydLRjB-L7Nw",
+    "updated_at": "2020-01-05 13:42:25.628594",
+    "url": "https://api.chucknorris.io/jokes/VK-7RRBMR4mydLRjB-L7Nw",
+    "value": "Chuck Norris can roundhouse kick Batman's prep time"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.628594",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "p8viz37nQg-h2tnmfADLng",
+    "updated_at": "2020-01-05 13:42:25.628594",
+    "url": "https://api.chucknorris.io/jokes/p8viz37nQg-h2tnmfADLng",
+    "value": "Chuck Norris once round house kicked a bear while on a survival trek in Siberia. That incident was known as the Tunguska event."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.628594",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "xAPAz0NSS0eNMcvU6ctAFA",
+    "updated_at": "2020-01-05 13:42:25.628594",
+    "url": "https://api.chucknorris.io/jokes/xAPAz0NSS0eNMcvU6ctAFA",
+    "value": "Chuck Norris kicked-in The Amazing Kreskin's face. Thus proving a Chuck Norris attack to be an unpredictable life event."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.628594",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "98zAHGcuSdGKzJ7Emu8O5w",
+    "updated_at": "2020-01-05 13:42:25.628594",
+    "url": "https://api.chucknorris.io/jokes/98zAHGcuSdGKzJ7Emu8O5w",
+    "value": "All individuals that have remarkably survived a Chuck Norris attack suffer what in medical terms is called 'optical rectumitis'. That being having their assholes kicked out through their eyesockets"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.628594",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "4e2mjAtcRCKO-AMEc9ZoHw",
+    "updated_at": "2020-01-05 13:42:25.628594",
+    "url": "https://api.chucknorris.io/jokes/4e2mjAtcRCKO-AMEc9ZoHw",
+    "value": "When Chuck Norris was born he round house kicked the Doctor in the face Slow mo' 3 times for slapping his ass."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.628594",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ZESuESQ1QpqWGWYQORZVQQ",
+    "updated_at": "2020-01-05 13:42:25.628594",
+    "url": "https://api.chucknorris.io/jokes/ZESuESQ1QpqWGWYQORZVQQ",
+    "value": "Most people get their heat from the sun, the sun gets it heat from a single Chuck Norris roundhouse kick"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.628594",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "BLwMnqzESFqIpI6NHSCp6w",
+    "updated_at": "2020-01-05 13:42:25.628594",
+    "url": "https://api.chucknorris.io/jokes/BLwMnqzESFqIpI6NHSCp6w",
+    "value": "In \"Wanted Dead Or Alive\", the lyric \"I've seen a million faces, and rocked them all\" is dedicated to Chuck Norris. Of course, the word 'rocked' is an euphemism for 'roundhose-kicked'."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.628594",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "kdJCg4cmRZ6w74I3MptLMA",
+    "updated_at": "2020-01-05 13:42:25.628594",
+    "url": "https://api.chucknorris.io/jokes/kdJCg4cmRZ6w74I3MptLMA",
+    "value": "Chun kuk do- founded by Chuck Norris in 1990- is an amalgamation of Korean tang soo do, shotokan karate, subak, taekkyon, judo and Brazilian jiu-jitsu. In other words, it's the juice that powers his epic roundhouse kicks."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.628594",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "QY4jiLa2T86erJtWJ5elXA",
+    "updated_at": "2020-01-05 13:42:25.628594",
+    "url": "https://api.chucknorris.io/jokes/QY4jiLa2T86erJtWJ5elXA",
+    "value": "Chuck Norris head may be in the clouds but his round house kick is in the back of your face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.628594",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "asYOIsAaRQewv9XTM5GLVA",
+    "updated_at": "2020-01-05 13:42:25.628594",
+    "url": "https://api.chucknorris.io/jokes/asYOIsAaRQewv9XTM5GLVA",
+    "value": "In the beginning there was nothing, then Chuck Norris kicked that nothing in the face and said \"Get a job!!\"... And that's the story of the universe."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.628594",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "F4HAIPk6Q3W7KIseFR9sNQ",
+    "updated_at": "2020-01-05 13:42:25.628594",
+    "url": "https://api.chucknorris.io/jokes/F4HAIPk6Q3W7KIseFR9sNQ",
+    "value": "Did you know if you watch the editors cut of Wizard of Oz, theres and alternate ending where Chuck Norris round house kicks Dorothys house back to Kansas... it shortened the movie drastically and the director decided not to use it... true story."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.628594",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "POgbrE-DTxuJ8nmS_KRDdQ",
+    "updated_at": "2020-01-05 13:42:25.628594",
+    "url": "https://api.chucknorris.io/jokes/POgbrE-DTxuJ8nmS_KRDdQ",
+    "value": "The reason Cobra Commander wears a mask coz his face was disfigured by a roundhouse kick from Chuck Norris by simply mentioning his name."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.628594",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "50IKn3UcRtG6s3XC0MihtQ",
+    "updated_at": "2020-01-05 13:42:25.628594",
+    "url": "https://api.chucknorris.io/jokes/50IKn3UcRtG6s3XC0MihtQ",
+    "value": "Human beings celebrate new years. Chuck Norris celebrates new seconds - and go about with his roundhouse kicking business. That's how fast Chuck Norris is."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "sCJVvS9eS--Tyut3QIVmoA",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/sCJVvS9eS--Tyut3QIVmoA",
+    "value": "Chuck Norris roundhouse kicked Cher and turned back time."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ccyFKy17Q6WqLTFkR0Y8Fg",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/ccyFKy17Q6WqLTFkR0Y8Fg",
+    "value": "It's said that, when this website gets to Fact #9001, Chuck Norris will kick it in the URL, rocketing it up to 10,000 facts."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "BjSs_8lPTcWJft-vY-iC7A",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/BjSs_8lPTcWJft-vY-iC7A",
+    "value": "Many people wonder why Star Wars begins with \"A long time ago, in a galaxy far, far away\"... Well, Chuck Norris roundhouse kicked all the jedi, clones & other aliens in that galaxy and moved to ours."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "hdoWo7ZvT0K21cmqYNl94Q",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/hdoWo7ZvT0K21cmqYNl94Q",
+    "value": "On people magazine Justin Beiber said this about Chuck Norris \"Hes awsome if I met him hed probbaly round-house kick me in the face\" he joked"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "RCYGaqbYRymxXHKBTA892w",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/RCYGaqbYRymxXHKBTA892w",
+    "value": "Death once visited Chuck Norris,CHuck Norris said\"DON'T EVER TELL CHUCK NORRIS WHEN HE DIES,I TELL YOU WHEN YOU DIE.\"Then Chuck delievered the most powerful roundhouse kick ever and even Death knew he did something wrong as he declined into hell."
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "GDmkZ0j0T92BKp6kLcOs4g",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/GDmkZ0j0T92BKp6kLcOs4g",
+    "value": "Having a tick on the head of your dick is better than receiving a Chuck Norris roundhouse kick in your neck."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "1Uz3bpy_RyeBLcD5H4hzkA",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/1Uz3bpy_RyeBLcD5H4hzkA",
+    "value": "Mr. T, Arnold Shcwarzzenger, and Chuck Norris are standing in front of God. God says to them,\"I have call you three here because you are the greatest fighters in the world and I have a place for one of you at my right hand. You must prove to me whom of you it shall be.\" Mr. T steps and says \"I pity the fool who doesn't let me sit at His right hand.\" God tells him that he was not good enough and sends Mr. T to hell. Arnold steps up and says \"I was in predator, commando, the terminator. You must choose the governator.\" God tells him not good enough and sends Arnold to hell. God turns to Chuck Norris and say \"Why should you sit beside me?\" Chuck quickly proceeds to roundhouse kick God in the face and say \"Bitch, your in my seat."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "2bHq32mOS9m5IHGEZChzSQ",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/2bHq32mOS9m5IHGEZChzSQ",
+    "value": "Chuck Norris will personally roundhouse kick you if you don't get off this website and get back to work!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "X-0Kx8WaTqW-7Idyv2Ah_w",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/X-0Kx8WaTqW-7Idyv2Ah_w",
+    "value": "The last person to attempt to emulate a Chuck Norris roundhouse kick lost his kneecap due to the high intensity centrifugal force."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "TS5MAdPNTk2oXdUvbuJSgA",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/TS5MAdPNTk2oXdUvbuJSgA",
+    "value": "Chuck Norris reaches 11 on the Richter Scale, if you confront him and say it only goes to 10 you will recieve a roundhouse kick..which will reach 12."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "jJLsWfpPRoSPEVtKelXx2w",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/jJLsWfpPRoSPEVtKelXx2w",
+    "value": "The movement of subatomic air substance created from Chuck Norris' roundhouse kicks were recently accredited by physicists as allowing them to view the Higgs Boson Partical."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "0wIjXd4ASTS5Kogij9NTFA",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/0wIjXd4ASTS5Kogij9NTFA",
+    "value": "Chuck Norris never went to karate class, he was born kicking butt."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "tpg9R8inQz6l93Qp2OkFWA",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/tpg9R8inQz6l93Qp2OkFWA",
+    "value": "Chuck Norris never dances, he prefers roundhouse-kicking."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "7Ozov-CWR0erDeszZHME9g",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/7Ozov-CWR0erDeszZHME9g",
+    "value": "Who let the dogs out? Chuck Norris. He them proceeded to roundhouse kick each and every one of them."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "7aDT0NMmTQKfBRjIEf9hQQ",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/7aDT0NMmTQKfBRjIEf9hQQ",
+    "value": "Chuck Norris wil always kick your arse. Even in soviet russia."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "TylvCYzaTnqAwZ731qlZVQ",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/TylvCYzaTnqAwZ731qlZVQ",
+    "value": "One time Sylvester Stallone got into an argument with Chuck Norris over who was the best knitter. Chuck Norris roundhouse kicked him in the face. Stallone's lip hasn't been the same since."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Fx89tC2xR9Sssjb5srCDlA",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/Fx89tC2xR9Sssjb5srCDlA",
+    "value": "Chuck Norris keeps pirhanas in his swimming pool. He feeds them one freshly roundhouse-kicked pool cleaner daily."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "hgBrITAKRpCyQvEGhJ8FOA",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/hgBrITAKRpCyQvEGhJ8FOA",
+    "value": "I'm making a game called Ultra Smash Flash. Chuck Norris will be playable. And Kirby can use his roundhouse kick. Also, the Chaos Emeralds will be transformational items. When Chuck Norris gets 7, his power is STILL less than 1% of his real life counterpart. Makes sense, right? Quality, NOT quantity? NOPE. Quality AND quantity! Let's do this!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "51YtucrPTo6moA3Q6N6Gbw",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/51YtucrPTo6moA3Q6N6Gbw",
+    "value": "Chuck Norris beleives in downsizing government! That's why he once roundhouse kicked the Octagon. Today, its known as the Pentagon."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "8roiIntDRyy2NrOP2aS6TA",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/8roiIntDRyy2NrOP2aS6TA",
+    "value": "Chuck Norris roundhouse kicked the winnyness out of Caillou."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:25.905626",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "WL0spzxeSd--m6IiMBYDog",
+    "updated_at": "2020-01-05 13:42:25.905626",
+    "url": "https://api.chucknorris.io/jokes/WL0spzxeSd--m6IiMBYDog",
+    "value": "Chuck Norris once visited the Oracle and told her: 'Don't worry about the round house kick'. She responded: 'What round house kick?'. BAMM... that round house kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.194739",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "t1HQRTDFRKG0yKzXf_4NnA",
+    "updated_at": "2020-01-05 13:42:26.194739",
+    "url": "https://api.chucknorris.io/jokes/t1HQRTDFRKG0yKzXf_4NnA",
+    "value": "Following a recent kickboxing training mishap,Chuck Norris no longer has a shadow."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.194739",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "XZIptzobQaqizCRAG3JGyg",
+    "updated_at": "2020-01-05 13:42:26.194739",
+    "url": "https://api.chucknorris.io/jokes/XZIptzobQaqizCRAG3JGyg",
+    "value": "Chuck Norris wishes you a Roundhouse Kicking New Year!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.194739",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Ro5R7s-gQzSypDU12CEVJA",
+    "updated_at": "2020-01-05 13:42:26.194739",
+    "url": "https://api.chucknorris.io/jokes/Ro5R7s-gQzSypDU12CEVJA",
+    "value": "Chuck Norris fought the law, and the law got roundhouse kicked in the face"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.194739",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "edHHVdlpQLSZ-JcuhmYOwg",
+    "updated_at": "2020-01-05 13:42:26.194739",
+    "url": "https://api.chucknorris.io/jokes/edHHVdlpQLSZ-JcuhmYOwg",
+    "value": "Like this fact if Chuck Norris should kill Obama Dislike this fact if Chuck Norris should roundhouse kick you."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.194739",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "RvPofpJBRSWAA7_Ce6LlWw",
+    "updated_at": "2020-01-05 13:42:26.194739",
+    "url": "https://api.chucknorris.io/jokes/RvPofpJBRSWAA7_Ce6LlWw",
+    "value": "At birth, Chuck Norris immediately excised his parasitic twin, instantly roundhouse kicked his ass and threw him out the 10th story hospital room. We now know the parasitic twin as PeeWee Herman."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.194739",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "tQVxZpeFTV2QVnKm2Hgrhw",
+    "updated_at": "2020-01-05 13:42:26.194739",
+    "url": "https://api.chucknorris.io/jokes/tQVxZpeFTV2QVnKm2Hgrhw",
+    "value": "Every night before bed Chuck Norris round house kicks 10 childern."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.194739",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "tKTVXD9BT4iQCadidzsmJA",
+    "updated_at": "2020-01-05 13:42:26.194739",
+    "url": "https://api.chucknorris.io/jokes/tKTVXD9BT4iQCadidzsmJA",
+    "value": "Chuck Norris doesn't defy gravity. He simply kicks it in the nuts."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.194739",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "EbuTcwUZSi6SftbGIzYI5Q",
+    "updated_at": "2020-01-05 13:42:26.194739",
+    "url": "https://api.chucknorris.io/jokes/EbuTcwUZSi6SftbGIzYI5Q",
+    "value": "Only 535 people of thousands have ever survived a Chuck Norris roundhouse kick to the head. These, now brain damaged, individuals comprise the US Congress."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.194739",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "sPMJFA4zSIaIWIjHAkEJPQ",
+    "updated_at": "2020-01-05 13:42:26.194739",
+    "url": "https://api.chucknorris.io/jokes/sPMJFA4zSIaIWIjHAkEJPQ",
+    "value": "When Chuck Norris comes to an open door, he always closes it so he can then kick it the fuck in."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.194739",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "YS53dMJXTpax3UxUeoDlyg",
+    "updated_at": "2020-01-05 13:42:26.194739",
+    "url": "https://api.chucknorris.io/jokes/YS53dMJXTpax3UxUeoDlyg",
+    "value": "Jean-Claude Van Damme once attempted to throw a Chuck Norris Roundhouse Kick. He was immediately arrested for fraud."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.194739",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "PT4mQFuQRh6am-zXha6Ssg",
+    "updated_at": "2020-01-05 13:42:26.194739",
+    "url": "https://api.chucknorris.io/jokes/PT4mQFuQRh6am-zXha6Ssg",
+    "value": "A Chuck Norris roundhouse kick to your solar plexus will cause your toenails to crack."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.194739",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "7wz-Ze_mQcKaBSl053IFVg",
+    "updated_at": "2020-01-05 13:42:26.194739",
+    "url": "https://api.chucknorris.io/jokes/7wz-Ze_mQcKaBSl053IFVg",
+    "value": "Chuck Norris has two types of hearing, two types of smell, and nine types of sight. And 52 types of kickass."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.194739",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "GxhpqJDERvGwmLKJ4VgO5g",
+    "updated_at": "2020-01-05 13:42:26.194739",
+    "url": "https://api.chucknorris.io/jokes/GxhpqJDERvGwmLKJ4VgO5g",
+    "value": "James Bond says his name twice to introduce himself. Chuck Norris just roundhouse kicks you in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.194739",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "AIJNar9XRz-X_QRaNFdAuw",
+    "updated_at": "2020-01-05 13:42:26.194739",
+    "url": "https://api.chucknorris.io/jokes/AIJNar9XRz-X_QRaNFdAuw",
+    "value": "Chuck Norris Roundhouse kicked the Earth, It's been spinning ever since...."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.194739",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "NaJ7ClZXSNqrBaY1jUaDHA",
+    "updated_at": "2020-01-05 13:42:26.194739",
+    "url": "https://api.chucknorris.io/jokes/NaJ7ClZXSNqrBaY1jUaDHA",
+    "value": "You must always pay attention while driving, in case you are distracted for a split second and Chuck Norris drop-kicks a midget through your windscreen"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.194739",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "VshAHBHCSiW-NBlmab93Vw",
+    "updated_at": "2020-01-05 13:42:26.194739",
+    "url": "https://api.chucknorris.io/jokes/VshAHBHCSiW-NBlmab93Vw",
+    "value": "There are plenty of Chucks, but only one Chuck Norris- he roundhouse kicks anyone named after him."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "d0WjKV-cQEuqxTjmQggQsg",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/d0WjKV-cQEuqxTjmQggQsg",
+    "value": "Chuck Norris kicked the bucket-and lived."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "qH-x3PBUR6ugo-1_TJ9udA",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/qH-x3PBUR6ugo-1_TJ9udA",
+    "value": "Before sliced bread, people used to say, \"That's the greatest thing since Chuck Norris.\" But Chuck Norris was displeased by this. So he roundhouse kicked a loaf of bread into slices."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "toRr7TfST_GipdLOzAreCA",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/toRr7TfST_GipdLOzAreCA",
+    "value": "Chuck Norris killed the greek warrior achilles with a roundhouse kick to his face. Then one night Chuck Norris made a joke he says \"Ah-kill-hes face!\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "1_7c22oOQYqRcxNxOSLlRQ",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/1_7c22oOQYqRcxNxOSLlRQ",
+    "value": "A man once asked Chuck Norris if it was true that he had cheated Death. Chuck Norris merely laughed and said \"Fool! I am Death\" and proceeded to roundhouse kick him mercilessly."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ArhxJ8zJR9e5FgaKP0AJWQ",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/ArhxJ8zJR9e5FgaKP0AJWQ",
+    "value": "I would like to take this spot to remember Michael Jackson, who was pronounced dead on the 25th. He was the King of Pop, and we will all miss him. Rest in peace. Suspected cause of death: A Chuck Norris delivered roundhouse kick to the face. Evidence: Missing nose, giant bootprint."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ZEuqShFfTYWbKvZz8U1TpQ",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/ZEuqShFfTYWbKvZz8U1TpQ",
+    "value": "Chuck Norris was kicked off the show \"Extreme Couponing\" the producers couldn't stand watching entire grocery chains file bankruptcy because of Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "w1ODpbIIT-qWtyNq6arA7g",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/w1ODpbIIT-qWtyNq6arA7g",
+    "value": "All bad guys ever kicked by Chuck Norris in TV/movies immediatly died upon end of contract. Chuck Norris respects the Law."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "xD_qmXkgRnC36FV-bsRblQ",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/xD_qmXkgRnC36FV-bsRblQ",
+    "value": "Chuck Norris puts the C in Critical, the H in Hercules, the U in Unbeatable and the K in Kick... All together - CHUCK."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "RtqvU-4UR12whu1GrNVEWg",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/RtqvU-4UR12whu1GrNVEWg",
+    "value": "Chuck Norris house trained his dog by 1 roundhouse kick to the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "hxX8J_SMTeCwao3frW9gbQ",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/hxX8J_SMTeCwao3frW9gbQ",
+    "value": "Robin Hood was partially based on Chuck Norris, in that Norris would rob from the rich. But Robin Hood never roundhouse-kicked the poor. Or the rich, for that matter."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "G9xf1cllRpGf5IhEsmy5Mw",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/G9xf1cllRpGf5IhEsmy5Mw",
+    "value": "Atomic fusion is so powerful, it could power the U.S. for a day. Chuck Norris' roundhouse kick can power the Earth for 1,000 years."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "9yPOBZC5TFav0WvrlJplKw",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/9yPOBZC5TFav0WvrlJplKw",
+    "value": "Chuck Norris is the most venomous thing on earth. After moments of getting bit, you receive the following symptoms: fever, beard rash, tightness of jeans, and the feeling of getting kicked through a car."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Zv_oWNAkT-uo9pbeteoxKA",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/Zv_oWNAkT-uo9pbeteoxKA",
+    "value": "If you ever try to drop kick Chuck Norris, you should stay down there."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "5cENL20GSwevHSZsJPGZsQ",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/5cENL20GSwevHSZsJPGZsQ",
+    "value": "Chuck Norris is So Badass, he went to the island of Coradie to kick Ganon's Ass."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "pY3V-phXR1KuGQD3tc6Oeg",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/pY3V-phXR1KuGQD3tc6Oeg",
+    "value": "Chuck Norris single handedly roundhouse kicked the butt of every player, coach, waterboy and fan of the Florida State University Seminoles football team. They are now known as the Semiholes."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "w7JjSWxqQFm7bpXiLiK_kQ",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/w7JjSWxqQFm7bpXiLiK_kQ",
+    "value": "Chuck Norris discovered the theory of relativity. When Albert Einstein found out he decided to make it public. Chuck Norris got angry and roundhouse kicked him in the face. Albert Einstein is now known as Stephen Hawking."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "cueg2RtnSkSYJnaiTiWs8Q",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/cueg2RtnSkSYJnaiTiWs8Q",
+    "value": "Chuck Norris can kill Weegee (a evil invincable clone of luigi) in 1 roundhousekick"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "RZCyO99jShmwVLOu-ouhBA",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/RZCyO99jShmwVLOu-ouhBA",
+    "value": "Chuck Norris fact: John Merrick was Chuck Norris' identical twin. Chuck kicked his brothers butt inside his mothers womb for sucking on his thumb. John Merrick is known today as the elephant man."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "jWaZl5XBSG-YCKe8KRcB5g",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/jWaZl5XBSG-YCKe8KRcB5g",
+    "value": "Chuck Norris often works out in public. He was spotted last week on Hwy 66 roundhouse kicking tornados as a warm up."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "HbU_RItxSG6dzuscqHLBog",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/HbU_RItxSG6dzuscqHLBog",
+    "value": "There was a band named the Chuck Norrises. It was then banned because the band threatened the viewers with roundhouse kicks, including Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "OUWK6JsrSfa21luvJbR4Kg",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/OUWK6JsrSfa21luvJbR4Kg",
+    "value": "Chuck (engineering), a clamp that is part of a machine tool (e.g., lathe) or power tool (e.g., drill) and securely holds a removable part, either a workpiece or a tool (e.g., drill bit). Chuck Norris (asskicker), a superhuman roundhouse-kick machine that is primarily nocturnal, feeds upon beer and raw meat, and has a year-round mating season."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gCzZY8alSoeLZC6jziRCqA",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/gCzZY8alSoeLZC6jziRCqA",
+    "value": "SpongeBob SquarePants once called Chuck Norris a Crabby Patty sissy boy. An angy Chuck Norris then roundhouse kicked SpongeBob in the ass so hard that he had to legally change his name to SpongeBob NoRectumPants."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ftsSltITRsSZjrn-r1PGGQ",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/ftsSltITRsSZjrn-r1PGGQ",
+    "value": "The Hiroshima and Nagasaki nuclear explosions were NOT caused by Fat Man and Little Boy. They were caused by two Chuck Norris roundhouse kicks!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ZLx_uNhmTU2U48fdSl0IjQ",
+    "updated_at": "2020-01-05 13:42:26.447675",
+    "url": "https://api.chucknorris.io/jokes/ZLx_uNhmTU2U48fdSl0IjQ",
+    "value": "When Chuck Norris Roundhouse kicks your ass you say thank you sir may I have another."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ACOQrCbaS5GDR8DKysxHOQ",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/ACOQrCbaS5GDR8DKysxHOQ",
+    "value": "One time Jason Voorhees made fun of Chuck Norris during a hockey game. He roundhouse kicked Jason in the face so hard, he melded the goalie mask to his face, broke his vocal cords, and messed up his brain so much, he became a serial killer."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "kztCPkWlTFCHYIRBUehvlQ",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/kztCPkWlTFCHYIRBUehvlQ",
+    "value": "Rule #1: Chuck Norris is always right. Rule #2: Should Chuck Norris happen to be wrong he will roundhouse kick you back to rule #1."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "IbybCr5wTKePtqggVOZ5xA",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/IbybCr5wTKePtqggVOZ5xA",
+    "value": "A roundhouse kick to the crotch from Chuck Norris cures AIDS. Its too bad no one can survive a roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "XO8bBespRgClq05lTsnsIw",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/XO8bBespRgClq05lTsnsIw",
+    "value": "Most people receive Chuck Norris' kicks while he is wearing his cowboy boots. Receiving a bare-feet Chuck Norris roundhouse kick is considered auspicious in some countries."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "BYu2BMVcQc6iZozbea7RKQ",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/BYu2BMVcQc6iZozbea7RKQ",
+    "value": "If he wanted to, Chuck Norris could roundhouse kick you in the face with the ingrown hair on his ass even tho' he doesn't have one."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "jNTd1837QayvyPyqmyAq2g",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/jNTd1837QayvyPyqmyAq2g",
+    "value": "chucky does not play with Chuck Norris Chuck Norris plays with chucky by roundhouse kicking him over and over again"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "wRC5c4C2TRa3ES_cGte3Fw",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/wRC5c4C2TRa3ES_cGte3Fw",
+    "value": "If Chuck Norris imagines roundhouse kicking someone, that roundhouse kick actually hurts someone. Try not to imagine him imagining that."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "qnYHpr5QSpWp5tq7FQ2Xow",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/qnYHpr5QSpWp5tq7FQ2Xow",
+    "value": "If Chuck Norris round-house kicks you, you will die. If Chuck Norris' misses you with the round-house kick, the wind behind the kick will tear out your pancreas."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "nOA287_rSOSyIXjc9qRQew",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/nOA287_rSOSyIXjc9qRQew",
+    "value": "Mother Nature and Father Time came together and made Chuck Norris, But his name wasn`t always Chuck norris because it`s latin for I WILL KICK YOUR ASS."
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Nf8rEA-eTVOANlJiJ9Ir0Q",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/Nf8rEA-eTVOANlJiJ9Ir0Q",
+    "value": "Chuck Norris can break your neck with his tongue, tear your heart out with his eyelashes and kick you in the dick with enough force to leave a mushroom-shaped hole in the brick wall behind you."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ibMDwE5RTUCpHyT9yqOGfg",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/ibMDwE5RTUCpHyT9yqOGfg",
+    "value": "When Chuck Norris was born it wasn't his mother that pushed him out, he crawled out on his own, round house kicked the doctor and lit a cigar."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "W7U4VTN-S-KDYvLu6o-OFg",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/W7U4VTN-S-KDYvLu6o-OFg",
+    "value": "\"Like a good neighbor...\" Chuck Norris is there... with a roundhouse kick to the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "DVPMmcXjS3C7t0oioaQ6qg",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/DVPMmcXjS3C7t0oioaQ6qg",
+    "value": "Chuck Norris once killed a man with a roundhouse kick to someone else's face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ah7gStfKTPCseJJsJOTJYw",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/ah7gStfKTPCseJJsJOTJYw",
+    "value": "When Chuck Norris sees a screamer, he roundhouse kicks it so hard, that the ghost gets hit."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "XFUGyEmwQaK2ASAfnvEYEQ",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/XFUGyEmwQaK2ASAfnvEYEQ",
+    "value": "Chuck Norris can kick a fart back into an ass."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gldk0zH1Tqqa1-NHlHLn2A",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/gldk0zH1Tqqa1-NHlHLn2A",
+    "value": "Chuck Norris once round house kicked a retarded kids bus, and it became the first smart car."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "boaWowX4TfGtF3iARoFhMw",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/boaWowX4TfGtF3iARoFhMw",
+    "value": "How much wood can a woodchuck chuck, if a woodchuck chuck could chuck wood? This question is irrelevant. A relevant question would be \"How many trees can Chuck Norris kick the woodchuck through\"?"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "6DnR00l9SjOlb4ybLLEl6Q",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/6DnR00l9SjOlb4ybLLEl6Q",
+    "value": "All people say that the future is robots and futuristic buildings and technology. The real future is Chuck Norris as the ruler of the world. And ruler of roundhouse kicks and karate."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "nd-4EVIDSa69Y7pAlZPGXQ",
+    "updated_at": "2020-01-05 13:42:26.766831",
+    "url": "https://api.chucknorris.io/jokes/nd-4EVIDSa69Y7pAlZPGXQ",
+    "value": "Chuck Norris once accidentally killed a man by roundhouse kicking his shadow. The judge deemed the incident an Act of God and Chuck Norris walked a free man."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "qU47e6VyTI6Z0vrI72sPxQ",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/qU47e6VyTI6Z0vrI72sPxQ",
+    "value": "Whoever said \"Close enough only works for horseshoes and hand grenades\" obviously never witnessed what happens to people within a mile of a Chuck Norris roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "SiqCscf3R7-p6gwVR4FXvA",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/SiqCscf3R7-p6gwVR4FXvA",
+    "value": "When Chuck Norris goes to the club he doesnt dance, he does \"the Chuck Norris boogey\" aka roundhouse kicking everyone"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "P_zHOdMaSB6GwXgezQSIsQ",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/P_zHOdMaSB6GwXgezQSIsQ",
+    "value": "Chuck Norris' leg kicks hit hard enough to knock the polio vaccine out of your body"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "L7DLHAx9Txa0GEPWnWWcVw",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/L7DLHAx9Txa0GEPWnWWcVw",
+    "value": "Even if Chuck Norris is entirely tied with metal chains, he'll still kick your ass"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "QP6DG1ftRDCwNwhcbd6yUg",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/QP6DG1ftRDCwNwhcbd6yUg",
+    "value": "Chuck Norris jumped out of the Godly tree and roundhouse-kicked every branch on the way."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "phz8eDrnRM-WQ_Mfx66aZw",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/phz8eDrnRM-WQ_Mfx66aZw",
+    "value": "You know... Chuck Norris KNOWS Victoria's Secret... when he looks in the mirror his reflection runs away Probably his greatest accomplishment: He once round-house kicked someone so far his ody went back through time and hit Amelia Airheart's plane and it was shot down over the Pacific Ocean"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "F6CxYDlJRv-iy83fa3wKUQ",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/F6CxYDlJRv-iy83fa3wKUQ",
+    "value": "Chuck Norris is the only computer system that beats a Mac or a PC. Too bad all it does is round house kicks the user."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "jgtda9HrR6ydJofUCuhz_g",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/jgtda9HrR6ydJofUCuhz_g",
+    "value": "If you ever dream of beating Chuck Norris in a thumb war, the next event in said dream will be a 6734-ton weight falling on you. This is Chuck Norris's roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "sP2GYMlORKeAXxHVTQQMug",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/sP2GYMlORKeAXxHVTQQMug",
+    "value": "Chuck Norris was not born. He kicked his mother off of him."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "87eQtBjKT3eXcrX2wXa3Ew",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/87eQtBjKT3eXcrX2wXa3Ew",
+    "value": "A Chuck Norris flying roundhouse kick to the buttocks has been known to cause an infected, yellow pus filled abscess in hemorrhoidal tissue."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "IP6C9Iq4SDSR5rSTYUPr5A",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/IP6C9Iq4SDSR5rSTYUPr5A",
+    "value": "Chuck Norris doen't always drink beer. But when he does, he prefers to roundhouse kick \"The Most Interesting Man in the World\" in the face and take his Dos Equis. \"Stay thirsty my friends\"."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "jySyScEgR4eObSzOsJR6Lg",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/jySyScEgR4eObSzOsJR6Lg",
+    "value": "Slenderman once found Chuck Norris and then he came up and roundhouse kicked Slenderman in the face 100 times"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "HLQaEEqUQiOCUB6581N-iA",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/HLQaEEqUQiOCUB6581N-iA",
+    "value": "Chuck Norris doesn't kick people to the sun,he kicks the sun to people"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "OFLD9DntR2iKRb1IaVa4Vg",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/OFLD9DntR2iKRb1IaVa4Vg",
+    "value": "Proponents of higher-order theories of consciousness argue that consciousness is explained by the relation between two levels of mental states in which a higher-order mental state takes another mental state. If you mention this to Chuck Norris, expect an explosive roundhouse kick to the face for spouting too much fancy-talk."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "KFhtQ7m7SG22xEJZN-CKSA",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/KFhtQ7m7SG22xEJZN-CKSA",
+    "value": "Once a panhandler approached Chuck Norris and asked him for some change. Chuck Norris generously gave the poor man a quarter roundhouse kick and sent him hurtling into outer space at the speed of light."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "QInnPfVgSzuXoP-DcK4c8A",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/QInnPfVgSzuXoP-DcK4c8A",
+    "value": "One summer day, Chuck Norris was grilling steaks in his backyard when Bobby Flay approached him and challenged him to a Throwdown. Six hours later, surgeons were successful in reducing the swelling in Bobby's brain caused by a perfectly placed roundhouse kick to Bobby's temple. Prior to surgery, Bobby's head swelled up as big as Alton Browns head..."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "JY_FdtBZRUeEfGJ-reM1qA",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/JY_FdtBZRUeEfGJ-reM1qA",
+    "value": "It takes Chuck Norris 5 seconds to kick your ass... 80 times"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:26.991637",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "CJlrbtgwSsCzFoDdlKokWw",
+    "updated_at": "2020-01-05 13:42:26.991637",
+    "url": "https://api.chucknorris.io/jokes/CJlrbtgwSsCzFoDdlKokWw",
+    "value": "see the picture on top that has Chuck Norris' face on it? stare at it too long, and you will get a imaginary roundhouse kick to the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:27.496799",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ZG54JYBfRy-zuOqOBZwjIg",
+    "updated_at": "2020-01-05 13:42:27.496799",
+    "url": "https://api.chucknorris.io/jokes/ZG54JYBfRy-zuOqOBZwjIg",
+    "value": "If you ask Chuck Norris what time it is, he always says, \"Two seconds till.\" After you ask, \"Two seconds till what?\" He roundhouse kicks you in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:27.496799",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "OklJ3oTeREetkVkrrkyIOg",
+    "updated_at": "2020-01-05 13:42:27.496799",
+    "url": "https://api.chucknorris.io/jokes/OklJ3oTeREetkVkrrkyIOg",
+    "value": "It's the assholes like John West that Chuck Norris brutally roundhouse kicks, that makes Chuck Norris the best."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:27.496799",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "di3kL1L1RtC9ejtOoUAQNA",
+    "updated_at": "2020-01-05 13:42:27.496799",
+    "url": "https://api.chucknorris.io/jokes/di3kL1L1RtC9ejtOoUAQNA",
+    "value": "Chuck Norris once roundhouse kicked Mr Lawrence Thread so hard all that was left of his name was Mr T."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:27.496799",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "bFJWLxtHTr-jqQrrRC45fA",
+    "updated_at": "2020-01-05 13:42:27.496799",
+    "url": "https://api.chucknorris.io/jokes/bFJWLxtHTr-jqQrrRC45fA",
+    "value": "Once in olden times, Chuck Norris roundhouse kicked the ancient King of Canniptia in the face. Then, the remaining old world Canniptions threw a fit. Thank goodness the neighboring ruler of Hissyopia was not also kicked in the face or there would have also been a Hisssy fit to deal with!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:27.496799",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "duZi4UQrQXyQSk-aZuReUQ",
+    "updated_at": "2020-01-05 13:42:27.496799",
+    "url": "https://api.chucknorris.io/jokes/duZi4UQrQXyQSk-aZuReUQ",
+    "value": "Chuck Norris can roundhouse kick you around the world."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:27.496799",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "XkuHMhLLSOWtWXeJTBNC4Q",
+    "updated_at": "2020-01-05 13:42:27.496799",
+    "url": "https://api.chucknorris.io/jokes/XkuHMhLLSOWtWXeJTBNC4Q",
+    "value": "Contrary to popular folklore, Ebenezer Scrooge became filled with the true spirit of Christmas after he found out that Tiny Tim is Chuck Norris' nephew. And the fact that Chuck Norris relentlessly kicked his ass all night long on Christmas eve."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:27.496799",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "-ZncWPhhTqGjsSMpPBpWqA",
+    "updated_at": "2020-01-05 13:42:27.496799",
+    "url": "https://api.chucknorris.io/jokes/-ZncWPhhTqGjsSMpPBpWqA",
+    "value": "The end of the world is scared to come because Chuck Norris will round house kick is ass."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:27.496799",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "kswv7NIaTCaIIErlBzODaA",
+    "updated_at": "2020-01-05 13:42:27.496799",
+    "url": "https://api.chucknorris.io/jokes/kswv7NIaTCaIIErlBzODaA",
+    "value": "Chuck Norris's shadow weighs 250 pounds and can kick your ass ."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:27.496799",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "npKkMPjdTN2Z6cHJ9XashA",
+    "updated_at": "2020-01-05 13:42:27.496799",
+    "url": "https://api.chucknorris.io/jokes/npKkMPjdTN2Z6cHJ9XashA",
+    "value": "Popeye needs spinach to kick ass. Chuck Norris needs no such assistance."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:27.496799",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "kWvH5sdXSFOMaBtf9lUlGw",
+    "updated_at": "2020-01-05 13:42:27.496799",
+    "url": "https://api.chucknorris.io/jokes/kWvH5sdXSFOMaBtf9lUlGw",
+    "value": "Chuck Norris once read the entire Merriam-Webster dictionary backwards in pig-Latin, while roundhouse kicking 30 ninjas."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:27.496799",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "b6gbz95fSMaz5BnvwClIUw",
+    "updated_at": "2020-01-05 13:42:27.496799",
+    "url": "https://api.chucknorris.io/jokes/b6gbz95fSMaz5BnvwClIUw",
+    "value": "The only reason why the terrorist bombed the twin towers and the pentagon was because they thought Chuck Norris was in one of them. Now we got some of their countries because he roundhouse kicked most of them."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:27.496799",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "5FJU_qayQ1qYlB16uAaqQQ",
+    "updated_at": "2020-01-05 13:42:27.496799",
+    "url": "https://api.chucknorris.io/jokes/5FJU_qayQ1qYlB16uAaqQQ",
+    "value": "Chuck Norris CAN fool the Children Of The Revolution. Then roundhouse kick them in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:27.496799",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "PMEaoyYJTSKHMfETm3aW0Q",
+    "updated_at": "2020-01-05 13:42:27.496799",
+    "url": "https://api.chucknorris.io/jokes/PMEaoyYJTSKHMfETm3aW0Q",
+    "value": "don't send Chuck Norris e-mail. if it annoys him he can round house kick you thru Cyber Space!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:27.496799",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "2SJP5e9XSiS_EDq_8RVhJg",
+    "updated_at": "2020-01-05 13:42:27.496799",
+    "url": "https://api.chucknorris.io/jokes/2SJP5e9XSiS_EDq_8RVhJg",
+    "value": "Chuck Norris will soon open his own fried chicken restaurant chain: RKC-- Roundhouse Kickin' Chicken."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:27.496799",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "NHlYjBZyQCixXmCLm68EiA",
+    "updated_at": "2020-01-05 13:42:27.496799",
+    "url": "https://api.chucknorris.io/jokes/NHlYjBZyQCixXmCLm68EiA",
+    "value": "Everyone knew the world was flat,but they especially didn't want sail around the world because they knew if they fell then Chuck Norris would roundhouse kick them."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:27.496799",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "XWTybTMeRReeESiw77qjNA",
+    "updated_at": "2020-01-05 13:42:27.496799",
+    "url": "https://api.chucknorris.io/jokes/XWTybTMeRReeESiw77qjNA",
+    "value": "A sign at the entrance to NorrisWorld: 'You need to be at least this tall (30 microns) to die from a Chuck Norris roundhouse kick.'"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "AStmI8FRTTGoY6qBz3QwvA",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/AStmI8FRTTGoY6qBz3QwvA",
+    "value": "Chuck Norris name is in the webster's dictionary under roundhouse kick and above god."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "LayRiqOaQ9i31wD_FxYL3g",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/LayRiqOaQ9i31wD_FxYL3g",
+    "value": "A girl asked Chuck Norris to shave his beard. Chuck Norris roundhouse kicked her, and she grew taller and her hair grew shorter. That girl is now Justin Bieber."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "_zX0X0-eTDK5BiCIYvqi9w",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/_zX0X0-eTDK5BiCIYvqi9w",
+    "value": "Like a good neighbor, Chuck Norris is there to roundhouse kick you in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "TvmvY-VFQ8WNRtxU8LuMdw",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/TvmvY-VFQ8WNRtxU8LuMdw",
+    "value": "Chuck Norris is here to kick ass and take names, but doesn't bother to do that second thing."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ZZACzyAqSjKwBfDWgC1DqA",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/ZZACzyAqSjKwBfDWgC1DqA",
+    "value": "The reason why the truth hurts, is because Chuck Norris round-house kicked it in the face"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "saUW1ZpgQge7eZDYs5DRIw",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/saUW1ZpgQge7eZDYs5DRIw",
+    "value": "When asked how he wanted to die, Saddam Hussein requested a Chuck Norris roundhouse kick to the head. Saddam died instantly."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "2-5Dz9KUT264DjSunYaWYw",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/2-5Dz9KUT264DjSunYaWYw",
+    "value": "When does the Chuck Norris roundhouse kick strike? The answer is, anywhere, at any time, so hide in a hole forever...just in case he is looking for you."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "oxuCnu60R6uby3JC9mqWcw",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/oxuCnu60R6uby3JC9mqWcw",
+    "value": "Chuck Norris actually means God in spanish, english, german, roundhouse, arabic, french, assassin, italian and just go with it or he'll kick you"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "7B858RNRRMOu-f_DAoiN1Q",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/7B858RNRRMOu-f_DAoiN1Q",
+    "value": "The invasion of America in Modern Warfare 2 insulted Chuck Norris by blowing up his house - he walked across the Pacific to Russia and promptly roundhouse kicked Moscow in the face, thereby ending the war."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "hTlnETbpSteLWidqVMgeSA",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/hTlnETbpSteLWidqVMgeSA",
+    "value": "Jesus' last words, before giving up the ghost in Aramaic were \"Eloi Eloi lama sabachthani\". The approximate translation into modern English: Chuck Norris, Chuck Norris, please don't roundhouse kick me!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gnh21fOSTCuMd7011x9maQ",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/gnh21fOSTCuMd7011x9maQ",
+    "value": "Alls well that ends well. But if your life ends with a Chuck Norris roundhouse kick, all is not well."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "maAWglMPTPOp1tqZXleV7A",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/maAWglMPTPOp1tqZXleV7A",
+    "value": "Chuck Norris sold his soul to the devil for his rugged good looks and unparalleled martial arts ability. Shortly after the transaction was finalized, Chuck roundhouse kicked the devil in the face and took his soul back. The devil, who appreciates irony, couldn't stay mad and admitted he should have seen it coming. They now play poker every second Wednesday of the month."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "RChm8djZRx6Ovr0sH3aBeQ",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/RChm8djZRx6Ovr0sH3aBeQ",
+    "value": "Chuck Norris believes that for every action there is an equal and opposite roundhouse kick to your head."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "11Y5uvm9TNyUHZkhy7_zig",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/11Y5uvm9TNyUHZkhy7_zig",
+    "value": "CHuck norris can kick u with his hands, and punch u with his feet."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "uRxbNrPrQyahdB10YtRvVA",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/uRxbNrPrQyahdB10YtRvVA",
+    "value": "Chuck Norris roundhouse-kicked the nose off of the Sphinx."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "EAWzGqO9QdqOAjtY3MVPew",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/EAWzGqO9QdqOAjtY3MVPew",
+    "value": "When you search \"Chuck Norris getting his ass kicked,\" on any search machine, you will generate zero results. It just doesn't happen, and it never will too!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "yUNPIjOpQFGniYoPchEzZQ",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/yUNPIjOpQFGniYoPchEzZQ",
+    "value": "Once when Chuck Norris was denied a Bacon McDouble at McDonald's because it was 9:35, he roundhouse kicked the store so hard that it became a KFC."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Xh_WhWPGQM6Cpzi8hhVO0g",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/Xh_WhWPGQM6Cpzi8hhVO0g",
+    "value": "Chuck Norris can send his roundhouse kicks through the mail to everywhere, since he knows every address in the entire world! So don't be surprised if you see someone's head instantly explode from opening an envelope."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "W4hxZSdjSQmZGOpTSrYvLQ",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/W4hxZSdjSQmZGOpTSrYvLQ",
+    "value": "If you try to drop kick Chuck Norris, you should stay down there."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "rHyhP5RcSOyujHl6oahxvw",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/rHyhP5RcSOyujHl6oahxvw",
+    "value": "if you dont agree with Chuck Norris god management beware of roundhouse kick so"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Bjvu6u4oQSqGxUMhOSApiQ",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/Bjvu6u4oQSqGxUMhOSApiQ",
+    "value": "Newtons third law of motion states that Every action has a reaction equal in magnitude and opposite in direction When Chuck Norris uses his roundhouse kick there is only action."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "KyS1LU5bTT-ozlN9TeXclQ",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/KyS1LU5bTT-ozlN9TeXclQ",
+    "value": "Chuck Norris once shoved a watermelon up Gallagher's nose. Then shattered it with a flying roundhouse kick. Thus, proving that Gallagher is scatter-brained."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "RyKhhkLCSemv2kAKInSyKg",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/RyKhhkLCSemv2kAKInSyKg",
+    "value": "Chuck Norris once commented, \"There are few problems in this world that cannot be solved by a swift roundhouse kick to the face. In fact, there are none.\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "MZQwxwtFTo-3OvrGprhI7w",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/MZQwxwtFTo-3OvrGprhI7w",
+    "value": "If you somehow survive a roundhouse kick from Chuck Norris, you'd still go to jail for head butting his foot."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.143137",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "A6uXg0uJTjW74_qfyCm-Ww",
+    "updated_at": "2020-01-05 13:42:28.143137",
+    "url": "https://api.chucknorris.io/jokes/A6uXg0uJTjW74_qfyCm-Ww",
+    "value": "Roundhoused kicked by Chuck Norris... Life ruined forever."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "i71JHaBvSG-u8i4yodX5Yw",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/i71JHaBvSG-u8i4yodX5Yw",
+    "value": "Chuck Norris once kicked a horse in its chin. Its decendants are now known as giraffes."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "1V-TBXT6RDWczN4FZ8oovg",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/1V-TBXT6RDWczN4FZ8oovg",
+    "value": "The 1951 UFO sighting was actually a man hole cover kicked by Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "fT6GW5PaQG-PTgnH8dvWTQ",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/fT6GW5PaQG-PTgnH8dvWTQ",
+    "value": "There is a new unit of measurement called CNRKs [Chuck Norris Roundhouse Kicks]. 1 CNRK is enough to knock out something JUST tougher than 100000 lions. The Big Bang measured at 2 CNRKs, so far the only thing to certainly be more powerful than 1 CNRK. The Tsar Bomb, though, measured at a puny 0.0000327581 CNRKs, and the MOAB at 0.0000000000000000476738295873826782 CNRKs. The regular blink of a regular eye measured at an extremely puny 0.00000000000000000000000[insert 1000 zeroes here]6783758684 CNRKs."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "56gBgT03QTaU-7YyN0tFVA",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/56gBgT03QTaU-7YyN0tFVA",
+    "value": "Vin diesel got into a fight with Chuck Norris, and he kicked Chuck's ass and everyone cheered, Vin! Vin! Vin!..and Vin smiled at the adoring crowd...Vin! Vin!...but then Vin started waking up and slowly opened his eyes to find Chuck at his bed side, nudging at him, saying, Vin, Vin wake up..then Vin realized it was a dream, and Chuck Norris punched him in the fucking face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Kt5QkOxKRSunGGvndb_9CA",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/Kt5QkOxKRSunGGvndb_9CA",
+    "value": "Faces of Death is actually a biography of people that were given a choice other than a Chuck Norris roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Z8zHhxvFQ2Gp5spdHn2QZQ",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/Z8zHhxvFQ2Gp5spdHn2QZQ",
+    "value": "Chuck Norris was pissed off because George Washington was president, so he called him a pussy and roundhouse kicked George to the face"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "yzQDshvSRdO9bCGPqHAnbw",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/yzQDshvSRdO9bCGPqHAnbw",
+    "value": "Chuck Norris roundhouse kicks you in the head, his foot will actually go through your skin, skull and brain, then reappear out the other side. This is not magic, this is power. And if you survive, that would be magic."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "qb4z9b4kRBih6duymTEKVQ",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/qb4z9b4kRBih6duymTEKVQ",
+    "value": "Another way to explain a Chuck Norris Round House Kick to the face is \"de-materializing.\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "mtIJH_zKR3a6rB7ROa1ugg",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/mtIJH_zKR3a6rB7ROa1ugg",
+    "value": "Chuck Norris bought a double cheeseburger from McDonalds on the dollar menu for 2 dollars. He then proceeded to round house kick the cashier"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "l00PpeQcTAqizOpKdukHYA",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/l00PpeQcTAqizOpKdukHYA",
+    "value": "Chuck Norris once wrote...\"I will personally roundhouse kick anybody in the face that missplells words!\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ScJ-CedNQxOwISW5Ri97Lw",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/ScJ-CedNQxOwISW5Ri97Lw",
+    "value": "Chuck Norris's main method of preventing universe-shattering paradoxes consists of kicking people in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "kRCicvhcSlanwuB6SzOKvA",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/kRCicvhcSlanwuB6SzOKvA",
+    "value": "Freddy thought he was the true nightmare until he met Chuck Norris who roundhouse kicked and from that day Freddy hides in fear thinking a nightmare in texas"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "oO9tQRHeQhK5FQyqxzbe4Q",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/oO9tQRHeQhK5FQyqxzbe4Q",
+    "value": "Chuck Norris can make your nightmares come true. By roundhouse kicking you."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "RpemUFTcRjWrP2Ufp1dHQw",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/RpemUFTcRjWrP2Ufp1dHQw",
+    "value": "Chuck Norris knows how many kicks it takes to get to the center of a Tootsie Pop: one"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "S9WmnjNXRO-qYmkpE2MWHg",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/S9WmnjNXRO-qYmkpE2MWHg",
+    "value": "Sam Jackson is the only person to ever out-surf Chuck Norris at Chadderton baths. Incidentally, Chuck roundhouse kicked him in the face, and the force put him in a roundhouse induced coma for the rest of his natural life..."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "uy9WMmwOR32B4OZ_gunblA",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/uy9WMmwOR32B4OZ_gunblA",
+    "value": "When Chuck Norris was denied a Bacon McMuffin at McDonalds because it was 10:35, he roundhouse kicked the store so hard it became a KFC."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "5xncbuVAQIyDYzNcwzUVcQ",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/5xncbuVAQIyDYzNcwzUVcQ",
+    "value": "You know when you have so much fun it feels like time flies by so fast....... That's Chuck Norris telling Father Time to hurry up and get to the part where he roundhouse kicks you to death"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "YB8v9TUCT4ulgh8cNQxHrg",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/YB8v9TUCT4ulgh8cNQxHrg",
+    "value": "Chuck Norris doesn't use a microwave to pop his popcorn. He simply sits the package on the counter and the kernals jump in fear of a round house kick"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "i3uBQXJxSLqxd18Ukxtb4g",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/i3uBQXJxSLqxd18Ukxtb4g",
+    "value": "Chuck Norris once roundhouse kicked SpongeBob SquarePants in the butt so hard that SpongeBob had to legally change his name to SpongeBob ParallelogramPants."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "JkvDLDWeQC2i_80Csh7nBg",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/JkvDLDWeQC2i_80Csh7nBg",
+    "value": "Chuck Norris is the only man who can kick the shit OUT of you, then back in."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "HT825IiPR9qy6vvxlA_hQQ",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/HT825IiPR9qy6vvxlA_hQQ",
+    "value": "After seeing ''The Blair Witch Project'', Chuck Norris went into the woods, found the Blair Witch, and roundhouse-kicked it repeatedly until it died. When Chuck Norris pays 6 dollars to see a witch movie, you'd better show him a fuckin' witch."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.420821",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "vhfit3aqTWSwXi3wdMXU1w",
+    "updated_at": "2020-01-05 13:42:28.420821",
+    "url": "https://api.chucknorris.io/jokes/vhfit3aqTWSwXi3wdMXU1w",
+    "value": "In the beginning, there was nothing. Then Chuck Norris roundhouse kicked the universe in the face and said \"get a job\"."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "jRwlxEy2RGGwPirAZLx9Bw",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/jRwlxEy2RGGwPirAZLx9Bw",
+    "value": "There are only three things in the world that are a sure kill. 1. Kirby's Super Inhale. 2. Captain Falcon's Falcon Punch. 3. Chuck Norris's Roundhouse Kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "fk6pNHIjQyyYZM-6Pbq8Fg",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/fk6pNHIjQyyYZM-6Pbq8Fg",
+    "value": "Inspired by the 2004 Athens Olympics, Chuck Norris invented the roundhouse kick dive while visiting New Orleans..it's now known as Katrina"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "OOb_lOJ1Rp-s6pxMQx0yCA",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/OOb_lOJ1Rp-s6pxMQx0yCA",
+    "value": "As a youngster, just for kicks Chuck Norris would often tie up a neighborhood kid and tell him he'd be back in 30 minutes to kick his @$$. That man grew up to be Harry Houdini."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Ys9fVItSSSaVZ94tNEhDfw",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/Ys9fVItSSSaVZ94tNEhDfw",
+    "value": "Chuck Norris didn't like this joke, so he deleted it by roundhouse kicking it."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ASxszjoiSV67v3HEtcQreQ",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/ASxszjoiSV67v3HEtcQreQ",
+    "value": "A Chuck Norris fact a day keeps his roundhouse kicks away."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "3sSTpO_pR0CS3_wR5ERO2w",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/3sSTpO_pR0CS3_wR5ERO2w",
+    "value": "Chuck Norris can roundhouse kick the air around him and it bleeds wind."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "mYna0hUJS9KMWY-BzQpzaQ",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/mYna0hUJS9KMWY-BzQpzaQ",
+    "value": "Chuck Norris' earlobes can roundhouse kick your face through the back of your skull."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "PXxcEJDWSpyLW532ObC0EQ",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/PXxcEJDWSpyLW532ObC0EQ",
+    "value": "The pressure at the Earth's deepest point is more than 1000 times the normal atmospheric force, or about 1 tenth of the force of a Chuck Norris roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "rMQ2azTRToyx3KB4h5aLNQ",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/rMQ2azTRToyx3KB4h5aLNQ",
+    "value": "Chuck Norris went to the bottom of the bottomless pit, he was so pissed there was a bottom, he roundhouse kicked it and now it truly is bottomless"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "HW2FCG66SKeloYZR1wjn3A",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/HW2FCG66SKeloYZR1wjn3A",
+    "value": "If you don't make these jokes funny, Chuck Norris will run all the way around the world in a millasecond and roundhouse kick you in the face!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "aB4Puwq1RCSyrtkQNX0-Cg",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/aB4Puwq1RCSyrtkQNX0-Cg",
+    "value": "Chuck Norris invented oatmeal when he round house kicked a quaker."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "lj5tmV9WQpOy0SvKdAZ-rQ",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/lj5tmV9WQpOy0SvKdAZ-rQ",
+    "value": "Life is like a box of chocolates until Chuck Norris roundhouse kicks you."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "LpHcyuP_SPWcqadMXQduUQ",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/LpHcyuP_SPWcqadMXQduUQ",
+    "value": "Chuck Norris once roundhouse kicked a cotton field in Mississippi instantly creating the first Levis factory as well as adorning his torso with a sleeveless denim vest"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "3wVyRIDSRTGDPB7EBzdGLg",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/3wVyRIDSRTGDPB7EBzdGLg",
+    "value": "Chuck Norris once kicked a baby beluga whale into puberty."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "esHjeiRMS8SafK4lABg1jw",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/esHjeiRMS8SafK4lABg1jw",
+    "value": "Thanksgiving was fist celebrated by the Pilgrims near Plymouth Rock in 1621 because they were thankful that Chuck Norris wasn't there to kick thier ass."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "KCz_aN5iSB-Af9qmP6-MLQ",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/KCz_aN5iSB-Af9qmP6-MLQ",
+    "value": "By some odd reason,Chuck Norris is everywhere.That means he can be roundhouse kicking you,and jesus at the same time."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "D1JcDT75QvqaxlApjlZm5A",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/D1JcDT75QvqaxlApjlZm5A",
+    "value": "Chuck Norris can roundhouse kick you over the internet. Even if your computer is turned off. Or you don't have one."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "v5BLiczIRvKFup9bf-7BXg",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/v5BLiczIRvKFup9bf-7BXg",
+    "value": "Chuck Norris wrote a series of books called, \"How To Roundhouse Kick Like Chuck Norris\". Volume 13 contained only a very realistic Chuck Norris leg which would roundhouse-kick the reader. One survivor rewrote it from his point of view, and the series is now in few libraries, if not none."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "3mOKM6tKTc-lPCIKuDEA8w",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/3mOKM6tKTc-lPCIKuDEA8w",
+    "value": "The Internet was invented by Chuck Norris so that he could deliver roundhouse kicks worldwide from the comfort of his own home."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "IWp-NfZ_SoGSSFD6jWVfQg",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/IWp-NfZ_SoGSSFD6jWVfQg",
+    "value": "In order to sleep, Chuck Norris has to roundhouse kick himself in the face approximately 754 times. Even then, he still tosses and turns a little."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "oDEgbxIwR0i90RLXk_QNEA",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/oDEgbxIwR0i90RLXk_QNEA",
+    "value": "Contrary to popular belief, Chuck Norris, not the box jellyfish of northern Australia, is the most venomous creature on earth. Within 3 minutes of being bitten, a human being experiences the following symptoms: fever, blurred vision, beard rash, tightness of the jeans, and the feeling of being repeatedly kicked through a car windshield."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "oWEvFKD7QviJAbTrfhQTqg",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/oWEvFKD7QviJAbTrfhQTqg",
+    "value": "Chuck Norris invented happiness when he spared a mans life, when the man told his family, Chuck Norris roundhouse kicked him in the jaw thus ending the man and adding another hair to Chuck's beard!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.664997",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "uF_yaSWOTaOqNor-xlVo8g",
+    "updated_at": "2020-01-05 13:42:28.664997",
+    "url": "https://api.chucknorris.io/jokes/uF_yaSWOTaOqNor-xlVo8g",
+    "value": "Chuck Norris can eat or drink anything without a single stop while doing roundhouse kicks."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "-3CjPqg6SaKvAZBLgTp_6w",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/-3CjPqg6SaKvAZBLgTp_6w",
+    "value": "If you play Stairway to heaven backwards you hear a satanic message. If you play the theme song to Walker,Texas Ranger backwards you hear Chuck Norris kicking the Devils ass."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "nYj4tJQ-T4ioHrzbr8rFMg",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/nYj4tJQ-T4ioHrzbr8rFMg",
+    "value": "By the time you see Chuck Norris in your rearview mirror, he's already kicked you in the face and is 10 car lengths ahead of you."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "z7qvIUuwQr-iJ8IBK5zqXg",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/z7qvIUuwQr-iJ8IBK5zqXg",
+    "value": "Chuck Norris roundhouse kicked this fact."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "REaaJ4tNQaWB0FYXr23hwQ",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/REaaJ4tNQaWB0FYXr23hwQ",
+    "value": "The most obvious upside to receiving a brutal Chuck Norris roundhouse kick is is that you will enter the afterlife knowing that you have died the most awesome death possible."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "CM1AUaVrRHSTtzKbAHKpLw",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/CM1AUaVrRHSTtzKbAHKpLw",
+    "value": "When Chuck Norris asks to 'borrow' something from you, be aware that you will never, ever get it back and are in fact about to be kicked in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "s_akNmy_Rn2Q_mBZllZS6Q",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/s_akNmy_Rn2Q_mBZllZS6Q",
+    "value": "Chuck Norris was the Fourth Wiseman. He gave Baby Jesus the gift of Beard. Jesus loved it so much the other Wisemen were jealous of his obvious gift favoritism. They then used their combined influence to have Chuck Norris omitted from the Bible. All three later died mysteriously from roundhouse-kick related issues."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ODVOngJ1Tb6Kb-Q-TxBsCQ",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/ODVOngJ1Tb6Kb-Q-TxBsCQ",
+    "value": "Recently, a car salesman told Chuck Norris he needed to go green and drive a Toyota Prius. Chuck kicked the Prius across the parking lot then drove off in his Humvee."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "5LdFelEhSYyC7k9f3NQ4Lw",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/5LdFelEhSYyC7k9f3NQ4Lw",
+    "value": "Every year Chuck Norris' birthday, March 10 is celebrated as Voluntary Roundhouse Kick Day. On this special day people volunteer to be roundhouse kicked by Chuck Norris in the face to show him how much he is loved. The next day, Chuck Norris hunts down everyone who didn't volunteer and roundhouse kick them for offending him."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "plj3-pqiRWuomVQKAy_AwQ",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/plj3-pqiRWuomVQKAy_AwQ",
+    "value": "Chuck Norris can have his cake, eat it, then roundhouse kick you in the face with the extra power it gave him."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "yjEl_PU5T3qEjOe-glr4CA",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/yjEl_PU5T3qEjOe-glr4CA",
+    "value": "When Chuck Norris is in a particularly artistic mood, he likes to set up a large canvas and roundhouse kick people near it while wearing ice-skates."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "YAcLiPWrTFCYFcavRgprzg",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/YAcLiPWrTFCYFcavRgprzg",
+    "value": "A waiter at a restaurant once asked a guy what kind of steak he wanted, the guy said, \"A roundhouse\". A few minutes later someone walked up beside the guy that ordered the steak while he was reading the menu. Thinking that the person that walked up beside him was the waiter, he asked, \"Do you have my roundhouse yet?\". He looked up and saw that Chuck Norris was right beside him. Chuck Norris said, \"You bet your ass I do!\". Chuck Norris then roundhouse kicked the guy in the face and asked, \"How did that taste?\"."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Xe8PylgRRNmM8th0N8tQbA",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/Xe8PylgRRNmM8th0N8tQbA",
+    "value": "Colnel Sanders actually died by eleven of Chuck Norris' kicks and punches."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "4uGz2cWXQBa4Eg-tGtXGtA",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/4uGz2cWXQBa4Eg-tGtXGtA",
+    "value": "Once I came up with a very funny Chuck Norris joke and decided to tell that to the Man himself before anyone else in the world. On hearing the joke Chuck Norris gave me a swift roundhouse kick to the side of my head, ever since I can't remember what that joke was."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "YyDUUnNlQEWtSp771kjo1A",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/YyDUUnNlQEWtSp771kjo1A",
+    "value": "Chuck Norris was once in Street Fighter 2. He was then removed because beta testers experienced that every button makes Chuck Norris do a roundhouse kick. Beta testers then ask Chuck Norris about this \"Glitch\". Chuck Norris replys: \"That's no glitch.\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "6dH62rLeTj6_5pnHUVhElA",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/6dH62rLeTj6_5pnHUVhElA",
+    "value": "Chuck Norris beat Pac-Man without doing anthing.He roundhouse kicked all of the ghosts until they had a pool of blood all over the screen and Chuck Norris commented \"NOTHING STANDS CHUCK NORRIS'S FUCKING WAY!\" That qualifies as doing nothing"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ee7ysgofRHex2YSp20RqjA",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/ee7ysgofRHex2YSp20RqjA",
+    "value": "According to the Mayan civilization, the world will end in the year of 2012... They believe this to be true because they fear Chuck Norris is harnesting power for a final Round House Kick in that year"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "MDUr-14SR9iOaEIyt2N97g",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/MDUr-14SR9iOaEIyt2N97g",
+    "value": "Chuck Norris's Seasonal catchy musical number... We kick you a Merry Chuckmas... We kick you a Merry Chuckmas... We kick you a Merry Chuckmas and a Chuckie New Year."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "SQlpChLGSsGbRboyxBaxAw",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/SQlpChLGSsGbRboyxBaxAw",
+    "value": "Chuck Norris invented Hip Hop so that he could hate on Hip Hop artists and roundhouse kick them for his personal entertainment while watching Walker Texas Ranger on TV."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ctRXzRxMQX2XqvjV-9fBqg",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/ctRXzRxMQX2XqvjV-9fBqg",
+    "value": "There was never anything wrong with Achilles' heel until he got mad and decided to kick Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "u3glR1eVRAuY_fN5rzLsfw",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/u3glR1eVRAuY_fN5rzLsfw",
+    "value": "Chuck Norris' mom can kick your ass."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "5f9lpT9jS0mE17Dzy9cryg",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/5f9lpT9jS0mE17Dzy9cryg",
+    "value": "Chuck Norris can draw a picture of him kicking your ass, and send it you you a week in advance - and as soon you open it he will knock on your door, properly kick your ass, and you STILL won't know what the fuck happened."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:28.984661",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "W0WciFjUQKKCm5DzzeTWjA",
+    "updated_at": "2020-01-05 13:42:28.984661",
+    "url": "https://api.chucknorris.io/jokes/W0WciFjUQKKCm5DzzeTWjA",
+    "value": "Chuck Norris likes to keep his lawn growing tall and thick so that whenever he has unwanted visitors, he can slip out of his house unnoticed and stalk them like prey. He then jumps toward them like a magnificent lion of the African plains and delivers a fatal roundhouse kick to their face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "9cxTIo20TdOiGlxit3Nxrw",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/9cxTIo20TdOiGlxit3Nxrw",
+    "value": "When Chuck Norris was once working at Freddy's Fazbear's Pizza, he punched the manager and roundhouse kicked Freddy Fazbear in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "d7FFvqQzSeChAzUl8x-G3Q",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/d7FFvqQzSeChAzUl8x-G3Q",
+    "value": "In soviet Russia Chuck Norris still kicks your ass!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "9TGcubXgRSCOJwhLUAVUbA",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/9TGcubXgRSCOJwhLUAVUbA",
+    "value": "Chuck Norris's jeans are so tight to prevent excess oxygen from reaching his legs and causing involuntary Roundhouse Kicks."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "wbYn4fitSF-EjKBu8foZxQ",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/wbYn4fitSF-EjKBu8foZxQ",
+    "value": "I pledge allegiance to the flag of the United States of America. And to the Republic for which it stands, one nation under Chuck Norris, indivisible with liberty and roundhouse kicks for all."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "88KQGV8dRWm9p1J5Dr6NZQ",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/88KQGV8dRWm9p1J5Dr6NZQ",
+    "value": "The word \"upChuck\" came from the first time Chuck Norris round-house kicked someone in the stomach."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "XrZfSYAjSHC7n8Rj9PztvQ",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/XrZfSYAjSHC7n8Rj9PztvQ",
+    "value": "The formation of The Universe began when Chuck Norris roundhouse kicked the singularity."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "1pjrwjLRQ2a_aDjTvEFcgg",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/1pjrwjLRQ2a_aDjTvEFcgg",
+    "value": "Chuck Norris roundhouse-kicks saplings. This is because the saplings will turn into trees the instant after he does that."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "GblHBTbkTYWyJD3cDGJJaA",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/GblHBTbkTYWyJD3cDGJJaA",
+    "value": "Chuck Norris roundhouse kicked the black off Michael Jackson"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "r-KTBUQYTjKllCxkrI47yQ",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/r-KTBUQYTjKllCxkrI47yQ",
+    "value": "Chuck Norris' first roundhouse kick ever is now known as The Big Bang."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "17_vCLQYSOikVFVTEU2GJw",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/17_vCLQYSOikVFVTEU2GJw",
+    "value": "Chuck Norris carved his Thanksgiving turkey with a roundhouse kick."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "-jMF0mF7Rcu6tUiIZ49pkw",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/-jMF0mF7Rcu6tUiIZ49pkw",
+    "value": "Chuck Norris took the red pill, the blue pill, 4 horse tranquilizers and a handful of rat poison, washed it down with a bottle of bourbon, and roundhouse kicked Morpheus out of the Matrix. Norris then unplugged himself out ofthe Matrix by simply flexing, broke into Zion and roundhouse kicked Morpheus again, just because he's Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "YEMY6imrQd6uIzB5wZoLog",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/YEMY6imrQd6uIzB5wZoLog",
+    "value": "Someone once told Chuck Norris that a roundhouse kick is not the best kick. This has been noted in history as the worst mistake ever made."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "wkst_SI4Q6Gjo5mQrfcU1A",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/wkst_SI4Q6Gjo5mQrfcU1A",
+    "value": "During WWII Chuck Norris was drafted into the Army. He mercilessly roundhouse kicked everyone to death including Ally soldiers. Their resting place is now known as Arlington Cemetery."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "nwspkrnqQu22zzyLbXOYGg",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/nwspkrnqQu22zzyLbXOYGg",
+    "value": "\"Iron Man\" was originally going to be called \"Chuck Norris: The Movie,\" but everyone who knew about it got roundhouse kicked. Afterwords, Chuck Norris hired Robert Downey Jr. and had the movie called \"Iron Man\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "p4i2WQVpT7aHelaEksBPJw",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/p4i2WQVpT7aHelaEksBPJw",
+    "value": "A Chuck Norris sighting is considered extremely fortunate - if he did not roundhouse kick you."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "4bvl1JLQS-uQzDK2scuXRw",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/4bvl1JLQS-uQzDK2scuXRw",
+    "value": "If you ever hear Chuck Norris humming \"Ain't That a Kick In the Head,\" flee for your life. You don't want to be around to see what happens next."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "4uBBJcBlRCO7mgKZ1G29wg",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/4uBBJcBlRCO7mgKZ1G29wg",
+    "value": "Chuck Norris doesn't have to connect to knock you out with a roundhouse kick. He just needs to come close and the wind does the rest"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "DU3PFP5fQBCqy9YnKhBY1A",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/DU3PFP5fQBCqy9YnKhBY1A",
+    "value": "Chuck Norris was the fourth wise man, who gave baby Jesus the gift of beard, which he carried with him until he died. The other three wise men were enraged by the preference that Jesus showed to Chuck's gift, and arranged to have him written out of the bible. All three died soon after of mysterious roundhouse-kick related injuries."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "o9x27EU-TzirpKloUQQhGA",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/o9x27EU-TzirpKloUQQhGA",
+    "value": "A man with 3 arms and 3 legs once attempted to kick Chuck Norris' ass. Chuck dropped him with a flying roundhoue, took a shit on his face and turned him into a Dung Beetle."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "pNUF3mtZTmyVsoGLvbtM3A",
+    "updated_at": "2020-01-05 13:42:29.296379",
+    "url": "https://api.chucknorris.io/jokes/pNUF3mtZTmyVsoGLvbtM3A",
+    "value": "Man, I thought it was gonna rain today but Chuck Norris come&#65279; down and roundhouse kicked the weatherman."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "m2WVDVEsRiOfipqFvY37fA",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/m2WVDVEsRiOfipqFvY37fA",
+    "value": "Theres a computer virus named rndhsekck. If you open the virus, it roundhouse kicks you in the face..from Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "kayrLh6lQLWUe7O_bJDNtg",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/kayrLh6lQLWUe7O_bJDNtg",
+    "value": "Chuck Norris can roundhouse kick you in the balls, face, and back of the head at the same time."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Gem93NrBRrmPOXY5uEA9iQ",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/Gem93NrBRrmPOXY5uEA9iQ",
+    "value": "Borat shouted \"Yakshemash! I kiss you, hi five!\" and ran towards Chuck Norris. Chuck Norris roundhouse kicked the retard back to the glorious nation of Kazakhstan and caged him along with his brother Bilo. That's why there won't be Borat - II."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "wLJfEPOkROmcsR97JHqFRw",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/wLJfEPOkROmcsR97JHqFRw",
+    "value": "When Chuck Norris kicks you in the face, you know you're dead. When he kicks himself in the face, he knows he's alive!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "9j7vXlKBQvGqqLIxADRS_w",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/9j7vXlKBQvGqqLIxADRS_w",
+    "value": "Chuck Norris threw his first roundhouse kick on September 1st, 1945 at the age of five. The next day Japan surrendered -- coincidence ? I doubt it ."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "aD2ozH7uRzO0XmzY_6aAYg",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/aD2ozH7uRzO0XmzY_6aAYg",
+    "value": "Chuck Norris roundhouse kicked a man in a wheelchair in the ground people dug that fossil up it is now a handicap parking sign but really it is a warning that Chuck is coming"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ZparMV4QQ0e47-kU72lunw",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/ZparMV4QQ0e47-kU72lunw",
+    "value": "Scientists theorize that surviving a Chuck Norris roundhouse kick would be worse than dying from it. Unfortunately no-one has survived one to confirm this theory."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "MJ3W5zfzQOKkqUeLl6K8sA",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/MJ3W5zfzQOKkqUeLl6K8sA",
+    "value": "Chuck Norris was originally going to be in Kombat Pack 2 for Mortal Kombat X. They cancelled him because 1 roundhouse kick kills the opponent instantly. FATALITY!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "hmpdl8j1QFaBChl-PWbwhQ",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/hmpdl8j1QFaBChl-PWbwhQ",
+    "value": "Chuck Norris created the world when he roundhouse kicked a meteorite that was going fifty trillion miles per second. we know that event today as the Big Bang Theory."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Ds98E9edTsWWh80jIqtH0A",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/Ds98E9edTsWWh80jIqtH0A",
+    "value": "If Chuck Norris says \"Lets have fun!\", he actually wants to roundhouse kick you to space."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "IGpgyJgzS7qx-w6-zBafvw",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/IGpgyJgzS7qx-w6-zBafvw",
+    "value": "Life is like a brutal Chuck Norris roundhouse kick. It's more spectacular than you will ever know."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "A8ldyZvLR-2g9Zpa3ixrSA",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/A8ldyZvLR-2g9Zpa3ixrSA",
+    "value": "What is black, white and red all over? Chuck Norris roundhose kicked an actor in a black and white old movie."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "LQ2DCqlyQeie32ovFUf4Mg",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/LQ2DCqlyQeie32ovFUf4Mg",
+    "value": "If u spell CHUCK NORRIS without capitalizing his letters he'll wil roundhouse kick you 230,000,000 times less then a half a second and the only this u will see is your body in a coffin. It is a good thing that I capitalized his"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "fhW3jCFXQhyOEKbsTPUbGg",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/fhW3jCFXQhyOEKbsTPUbGg",
+    "value": "Chuck Norris once kicked a giraffes face to a snake. Now to this day the snake was called: \"Brontosaurus.\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "RdTozqhvRp2vFRK2Ucr5nQ",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/RdTozqhvRp2vFRK2Ucr5nQ",
+    "value": "Chuck Norris has a million Espurr. When they hug his legs, you better get the bleep out of there, or else you'll die a death worse than a roundhouse kick. Don't believe me? Have you even READ Espurr's Pokedex entries?"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "hWRLj-orS0CsvPF9jeoasg",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/hWRLj-orS0CsvPF9jeoasg",
+    "value": "Chuck Norris could kick your ass so hard that nine months after you die, your wife would give birth to his foot."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "KFB4ZxtaT4urvYsyskRqlg",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/KFB4ZxtaT4urvYsyskRqlg",
+    "value": "Touching Chuck Norris' beard will increase you life expectancy by 6 years. Unfortunately, the following roundhouse kick will reduce your life expectancy by 300. You do the math. \""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "JOf4UPM3Q1u-P-_SwGF9ww",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/JOf4UPM3Q1u-P-_SwGF9ww",
+    "value": "Face your problems, unless your face is the problem which Chuck Norris roundhouse kicked."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "v0HaBqQgREqivk90PkgKXw",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/v0HaBqQgREqivk90PkgKXw",
+    "value": "Chuck Norris roundhouse kicked PSY in the face Gangman Style."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "Fu7sDvizSSWqG0uau7cefw",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/Fu7sDvizSSWqG0uau7cefw",
+    "value": "Roses are red, Violets are blue, some poems rhyme, Chuck Norris kicked my ass."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "yfED8m0eRoyvW966-wOrnQ",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/yfED8m0eRoyvW966-wOrnQ",
+    "value": "If you ask Chuck Norris for his autograph, he'll dip his boot in a bucket of ink and roundhouse kick you in your face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "HpbMH3zQTG6QQ2avMBSmOg",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/HpbMH3zQTG6QQ2avMBSmOg",
+    "value": "A long time ago, in a galaxy far,far away.... Chuck Norris roundhouse kicked the shit out of somebody."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "VTHNXeIaTFCpoGSoNXlCMQ",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/VTHNXeIaTFCpoGSoNXlCMQ",
+    "value": "When Chuck Norris roundhouse kicks your nuts your face implodes on itself."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "BxTagLkVQEmA97AQq6UOxA",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/BxTagLkVQEmA97AQq6UOxA",
+    "value": "Chuck Norris will roundhouse kick you if you don't like this joke."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "4HWF0McBS8aO0PdVdQ7ycQ",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/4HWF0McBS8aO0PdVdQ7ycQ",
+    "value": "Chuck Norris can fix stupid with duct tape but he prefers to fix it with a roundhouse kick to stupid's face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "54Cmyi-hRTKHtxa4O1QSIQ",
+    "updated_at": "2020-01-05 13:42:29.569033",
+    "url": "https://api.chucknorris.io/jokes/54Cmyi-hRTKHtxa4O1QSIQ",
+    "value": "Chuck Norris was a first responder but he quit because people wanted him to use the defibrillators, and not roundhouse kicks."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.855523",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "RZ_7jhImRPuagtrsNBrfdQ",
+    "updated_at": "2020-01-05 13:42:29.855523",
+    "url": "https://api.chucknorris.io/jokes/RZ_7jhImRPuagtrsNBrfdQ",
+    "value": "Chuck Norris on the cast of The Expendables 2 means the movie will consist of opening credits, one roundhouse kick, and closing credits. A single shot will not be fired."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:29.855523",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "MODsqZwfRtiAEmeucHjh_w",
+    "updated_at": "2020-01-05 13:42:29.855523",
+    "url": "https://api.chucknorris.io/jokes/MODsqZwfRtiAEmeucHjh_w",
+    "value": "When Chuck Norris watches Bubble Guppies, he gets pissed off and jumps into the TV and roundhouse kicks the motherf$&!ing sh*t out of them."
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:29.855523",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "kxOR5qxOQGSMN0wQPxSjcQ",
+    "updated_at": "2020-01-05 13:42:29.855523",
+    "url": "https://api.chucknorris.io/jokes/kxOR5qxOQGSMN0wQPxSjcQ",
+    "value": "Chuck Norris tattooed his name onto Satan's penis at his request. Then roundhouse-kicked him."
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:29.855523",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "3l9qW5-NQyuCBxeGCMzmeg",
+    "updated_at": "2020-01-05 13:42:29.855523",
+    "url": "https://api.chucknorris.io/jokes/3l9qW5-NQyuCBxeGCMzmeg",
+    "value": "Chuck Norris has 2 deadly weapons - his roundhouse kick is a weapon of mass destruction while his penis is a weapon of mass reproduction."
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:29.855523",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "vUiilT9wTASrJr9srbJk0g",
+    "updated_at": "2020-01-05 13:42:29.855523",
+    "url": "https://api.chucknorris.io/jokes/vUiilT9wTASrJr9srbJk0g",
+    "value": "Last year Chuck Norris went to Cannes Film Festival. On seeing him, a huge crowd of fans gathered, chanting \"au-to-graph! au-to-graph!\" in unison. Not to disappoint his ardent fans, he delivered a lightning fast roundhouse kick to the nearest fan, dropping him dead instantly. Chuck Norris beamed. The terrified fans changed their chant to \"NO autograph! NO autograph! NO autograph!\". Chuck Norris gave all of them his autograph anyway. Later in the evening he had sex with Gisele Bundchen."
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:29.855523",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "f8F2axnhQgOBZ4fBFPprkg",
+    "updated_at": "2020-01-05 13:42:29.855523",
+    "url": "https://api.chucknorris.io/jokes/f8F2axnhQgOBZ4fBFPprkg",
+    "value": "Football was invented when Chuck Norris kicked a pig 100 yards and caught it before it hit the ground , knocking down 11large men in the process . Then he had sex with eight girls in short skirts with large pom-poms ."
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:29.855523",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ZVoYDHYOQLC_k2nY1SmCLg",
+    "updated_at": "2020-01-05 13:42:29.855523",
+    "url": "https://api.chucknorris.io/jokes/ZVoYDHYOQLC_k2nY1SmCLg",
+    "value": "Chuck Norris roundhouse kicked Blade so hard that he turned into that little gay vampire from Twilight."
+  }, {
+    "categories": ["political"],
+    "created_at": "2020-01-05 13:42:29.855523",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "urv99vobshwv4masls2teg",
+    "updated_at": "2020-01-05 13:42:29.855523",
+    "url": "https://api.chucknorris.io/jokes/urv99vobshwv4masls2teg",
+    "value": "The Manhattan Project was not intended to create nuclear weapons, it was meant to recreate the destructive power in a Chuck Norris Roundhouse Kick. They didn't even come close."
+  }, {
+    "categories": ["political"],
+    "created_at": "2020-01-05 13:42:29.855523",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "59GreidORcWWtxnSpqvX8Q",
+    "updated_at": "2020-01-05 13:42:29.855523",
+    "url": "https://api.chucknorris.io/jokes/59GreidORcWWtxnSpqvX8Q",
+    "value": "Chuck Norris, Jesus, and Barack Obama were standing by a lake. Jesus walked out on the water and was shortly followed by Chuck. Obama tried to follow, but fell in the water. After muck kicking and splashing Jesus said: Do you think we should tell him about the \"stepping stones\"? Chuck then said: \"What stepping stone?\""
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "HRXoKehCSaWao2GOa9i_og",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/HRXoKehCSaWao2GOa9i_og",
+    "value": "Chuck Norris knows how many roundhouse kicks to your asshole that it takes to create your personal hemorrhoid bouquet."
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "je5Hr3lfQTyvZZfvdoXudw",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/je5Hr3lfQTyvZZfvdoXudw",
+    "value": "On his first day at boot camp, young Chuck Norris was told by the drill sergeant to 'drop and give me twenty'. Naturally, Chuck roundhouse-kicked the asshole into the next state and was promoted to general later that day."
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "-u-4RmOiQGOh5xfxiOchtA",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/-u-4RmOiQGOh5xfxiOchtA",
+    "value": "Chuck Norris knows when to hold 'em, knows when to fold 'em... and knows when to kick the table over and blow away every asshole in the room."
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "TAl2IXxlR9qTWMVSc9Vv3w",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/TAl2IXxlR9qTWMVSc9Vv3w",
+    "value": "Chuck Norris could kick a faggot straight."
+  }, {
+    "categories": ["dev"],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ehvt5sspq9ytmr7q1mpjiw",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/ehvt5sspq9ytmr7q1mpjiw",
+    "value": "Chuck Norris solved the Travelling Salesman problem in O(1) time. Here's the pseudo-code: Break salesman into N pieces. Kick each piece to a different city."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "jM9XGoAHTu2Nozb5v3QDXA",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/jM9XGoAHTu2Nozb5v3QDXA",
+    "value": "The only person who can defeat Chuck Norris in the first round of an MC battle is MC Greeney. Chuck subsiquently roundhouse kicks Greeney in the face and kills him."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "KX-2r6LJQBCUX7fne4SEdw",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/KX-2r6LJQBCUX7fne4SEdw",
+    "value": "Chuck Norris just roundhouse kicked billy ray cyrus for mileys twerking"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "2Pu6NhLyR1OfxkRE5d2ObA",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/2Pu6NhLyR1OfxkRE5d2ObA",
+    "value": "Chuck Norris once glared at someone and the guys heart jump out of his chest out of fear. it didn't get far before Chuck Norris grabbed it and ate it. the only thing scarier than Chuck Norris glaring at you is him smiling while in the middle of a round house kick"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "YvYw0yqYQL6JAJvYu_XzZA",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/YvYw0yqYQL6JAJvYu_XzZA",
+    "value": "LIKE this and Chuck Norris won't roundhouse kick you"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "xuIKQFakSIiNX-8oOFqdLQ",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/xuIKQFakSIiNX-8oOFqdLQ",
+    "value": "You know when you have that feeling that you've seen all of this before....... That's just your life flashing before your eyes after Chuck Norris roundhouse kicked you in the face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "2Q9jTahRS2Kbv5LMPK_-Jw",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/2Q9jTahRS2Kbv5LMPK_-Jw",
+    "value": "If Chuck Norris were rea he would roundhouse kick me in the face befor I ekfvievheidciejdnckejdnjcknendc."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "NkbSN23uQiWGQVxG4V6O1g",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/NkbSN23uQiWGQVxG4V6O1g",
+    "value": "In the time it takes you to read this sentence, Chuck Norris will free two hundred POW's from a Vietnamese prison camp, roundhouse kick Saturn, and expose a dozen lucky women to a love so intense that they will be incinerated."
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "L-iXG44wRXijLVTZhlPZ9A",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/L-iXG44wRXijLVTZhlPZ9A",
+    "value": "Chuck Norris bought a van once with a bed in the back when a smart arse shows up and says i can't believe you did not buy a Mercedes Benz. Chuck Norris trying to stay calm says they don't make a Van the smart arse reply's i don't think you get it Mercedes Benz come with 3 inch windscreen wipers on on your headlines so you can always see where your going. Chuck Norris reply's with a smile I got a place to have sex with your daughter then round house kicked the guy"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "xAAGEowVTaaN5P0_-LvBSA",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/xAAGEowVTaaN5P0_-LvBSA",
+    "value": "\"I say dont worry about a thing. cause every little thing is gonna be alright...\" till you \"rise this morning with Chuck Norris at your door step... sayin im gonna round house kick you!\""
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "43r3uoa5SiuCliT44DdJow",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/43r3uoa5SiuCliT44DdJow",
+    "value": "When Chuck Norris round house kicked hulk hogan he turned into Britney spears and got sent to the seventh dimension that is power ful"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "a5XTcQaDRaWwerLw_AiCtg",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/a5XTcQaDRaWwerLw_AiCtg",
+    "value": "annoying orange is just a example what consequence can Chuck Norris do with roundhouse kick"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "T98Jcw4IRBSU4YLI-00BWA",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/T98Jcw4IRBSU4YLI-00BWA",
+    "value": "the reason the Grudge crokes is because Chuck Norris roundhouse kicked it in the throat"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "5NtimEDJSrqsnCad01jpGA",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/5NtimEDJSrqsnCad01jpGA",
+    "value": "cats don't mess with Chuck Norris, coz they know dat 1 kick from him equals to 5 cat lifes and we all know Chuck Norris doesn't kick once"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ZX3VWoEGSNCKwPnTsARbig",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/ZX3VWoEGSNCKwPnTsARbig",
+    "value": "Chuck Norris went to walmart once to buy a new laptop. they told him which was the best price. it was the $9.99 so chuck roundhouse kicked them and said i never asked for the price"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "PMkc-yk0QGCYRR0Nh_YNbQ",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/PMkc-yk0QGCYRR0Nh_YNbQ",
+    "value": "How do you spell roundhouse kick? C-h-u-c-k- N-o-r-r-i-s.(ignore this i needa say Chuck Norris)"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "GwIpQ1gyQRioaUirV3-Hqw",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/GwIpQ1gyQRioaUirV3-Hqw",
+    "value": "Stand 1 inch from Chuck Norris face-to-face, and he can still kick u in the top of the head!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "CAsLbpJKTqulIYT_U8rJGA",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/CAsLbpJKTqulIYT_U8rJGA",
+    "value": "the reason they found water on mars is because Chuck Norris round house kicked it in the face"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "wRR3mbdySdO8IrMx4CW48g",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/wRR3mbdySdO8IrMx4CW48g",
+    "value": "only you can prevent forest fires, only Chuck Norris can prevent roundhouse kicks..he just doesn't try"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ER5BmHCUTg2vTmU568ewmQ",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/ER5BmHCUTg2vTmU568ewmQ",
+    "value": "everyone on roblox is about to be roundhousekicked by Chuck Norris"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "oQjMIe5tTsOHITcyqBB_jQ",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/oQjMIe5tTsOHITcyqBB_jQ",
+    "value": "Shud up Phil you twat, me an Chuck Norris will kick your ass then were gonna chin whoever has been startin on will weston! fuck you anonymOus"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "dpJm7WuhTieUrnCYdEpDRA",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/dpJm7WuhTieUrnCYdEpDRA",
+    "value": "Its called the Chuck Norris roundhouse kick because it's delivered by Chuck Norris and when it strikes you, your head spins around and then you fly into a house."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "MuY7ZDrnR1mQm6gcfLJtjw",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/MuY7ZDrnR1mQm6gcfLJtjw",
+    "value": "Chuck Norris can kill two stones with one bird Chuck Norris ate a mouse an crapped out a cat 1+1=Chuck Norris Chuck Norris counted to infinite- twice Newtons' third Law states that every action has a equal and opposite reaction- this is a lie. there is no force equivalent to a Chuck Norris roundhouse kick if you need steel wool, take some of Chuck Norris' beard. Chuck Norris can cook air Chuck Norris punched a guy and he became a she Chuck Norris won the 1,000,000 dollar prize for performing telekinesis only chuck knows where amelia earhart went chuck kicked mario so hard he turned into luigi Chuck Norris got hit by a car. when the ambulance came, thhe found chuck standing up with half a car on each side of him"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "EDQRtDFKTRC8As6ApXcUvg",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/EDQRtDFKTRC8As6ApXcUvg",
+    "value": "Chuck Norris`s kicks are so fast ..you probably wudnt feel it till yesterday."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "hUgUhPNYSXa_sYt6NKxpgQ",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/hUgUhPNYSXa_sYt6NKxpgQ",
+    "value": "Yeah if anyone messes with will weston or ma bro gary i will kick their ass n shit on their graves and kill their children and shit on their childrens graves, also i think mc gr33n3ys rhymes are badass n Chuck Norris is a douchebag peace out from the nevilles :)"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.177068",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "JBoIfOe0TQawNbmLnbJrJg",
+    "updated_at": "2020-01-05 13:42:30.177068",
+    "url": "https://api.chucknorris.io/jokes/JBoIfOe0TQawNbmLnbJrJg",
+    "value": "Hurricans, tornados, etc are caused by Chuck Norris roundhouse kicking the wind."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.480041",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "lP6V4K5cT0CM8RXH1MqESA",
+    "updated_at": "2020-01-05 13:42:30.480041",
+    "url": "https://api.chucknorris.io/jokes/lP6V4K5cT0CM8RXH1MqESA",
+    "value": "Chuck Norris measurments are 10000-9000-30000000000000 the bottom piece is more bigger because he is best trained foot fighter(roundhousekick)"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.480041",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "0bTbvjwqRESWTyBSYNmAZw",
+    "updated_at": "2020-01-05 13:42:30.480041",
+    "url": "https://api.chucknorris.io/jokes/0bTbvjwqRESWTyBSYNmAZw",
+    "value": "The power level for Chuck Norris' roundhouse kick is infinity."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.480041",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "g96iRXO6TPWAgWkrWf_YRQ",
+    "updated_at": "2020-01-05 13:42:30.480041",
+    "url": "https://api.chucknorris.io/jokes/g96iRXO6TPWAgWkrWf_YRQ",
+    "value": "once upon a time Chuck Norris seen a mime\"hello\" said chuck the mime didnt answer so he round house kicked him to death."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.480041",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "XxmnFBzYSF-aW9j_ByDipw",
+    "updated_at": "2020-01-05 13:42:30.480041",
+    "url": "https://api.chucknorris.io/jokes/XxmnFBzYSF-aW9j_ByDipw",
+    "value": "Chuck Norris can kick the shit out of a stone till it bleeds"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.480041",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ZEH8hLiOTmWH2Rl4uvfd2Q",
+    "updated_at": "2020-01-05 13:42:30.480041",
+    "url": "https://api.chucknorris.io/jokes/ZEH8hLiOTmWH2Rl4uvfd2Q",
+    "value": "when ever Chuck Norris enters a room the song \"final count down\" begins to play, followed shortly by a roundhouse kick to your face."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.480041",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "tExOLgwDSOKUA_W3GcxFnQ",
+    "updated_at": "2020-01-05 13:42:30.480041",
+    "url": "https://api.chucknorris.io/jokes/tExOLgwDSOKUA_W3GcxFnQ",
+    "value": "Chuck Norris obtained his rugged good looks and martial art skills when he made a deal with the devil. once he received both gifts from satan Chuck Norris delivered a roundhouse kick to the devils skull and took his soul back. the devil who appreciated irony laughed at the attack. they now play golf every third tuesday of the month."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.480041",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gYOElvaLQZSZ9RFohTEbCQ",
+    "updated_at": "2020-01-05 13:42:30.480041",
+    "url": "https://api.chucknorris.io/jokes/gYOElvaLQZSZ9RFohTEbCQ",
+    "value": "Chuck Norris does not kick doors in, they are backing away from him!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.480041",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "JiERQMY4QM-swaA54r_I1g",
+    "updated_at": "2020-01-05 13:42:30.480041",
+    "url": "https://api.chucknorris.io/jokes/JiERQMY4QM-swaA54r_I1g",
+    "value": "Chuck Norris once helped an old lady across the street. When a car did not stop, he roundhoused kicked it thus creating the first mini. When the old lady thanked him he roundhoused kicked her for good measure."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.480041",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "H3ohJniuTVqdTouOZ1Evew",
+    "updated_at": "2020-01-05 13:42:30.480041",
+    "url": "https://api.chucknorris.io/jokes/H3ohJniuTVqdTouOZ1Evew",
+    "value": "what goes around comes around. what goes around Chuck Norris gets a roundhouse kick and never comes around."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.480041",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "bXavkEi8RmWFka1WGJAAZg",
+    "updated_at": "2020-01-05 13:42:30.480041",
+    "url": "https://api.chucknorris.io/jokes/bXavkEi8RmWFka1WGJAAZg",
+    "value": "a blind man once walked in to Chuck Norris chuck said do you know who i am im Chuck Norris. the mere mention of his name cured his blindness but sadly the first last and only thing he saw was a deadly round house kick to the face"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.480041",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ZqTlF-iQQ0SETmUOEfaYtw",
+    "updated_at": "2020-01-05 13:42:30.480041",
+    "url": "https://api.chucknorris.io/jokes/ZqTlF-iQQ0SETmUOEfaYtw",
+    "value": "the last person to survive a roundhouse kick by Chuck Norris was michael jackson. then he turned white"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.480041",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "rfgBofXNTi2KOf4edzsGvw",
+    "updated_at": "2020-01-05 13:42:30.480041",
+    "url": "https://api.chucknorris.io/jokes/rfgBofXNTi2KOf4edzsGvw",
+    "value": "Chuck Norris invented roundhouse kicking season"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.480041",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "QKIVzigWTBa6mZIRAhV48A",
+    "updated_at": "2020-01-05 13:42:30.480041",
+    "url": "https://api.chucknorris.io/jokes/QKIVzigWTBa6mZIRAhV48A",
+    "value": "Chuck Norris was model once a time..his measurments was 90-60-90.but upon a time he found roundhousekick and gain lots of muscles"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.480041",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "0v-8S0m9R4KYUDzDRcmrxQ",
+    "updated_at": "2020-01-05 13:42:30.480041",
+    "url": "https://api.chucknorris.io/jokes/0v-8S0m9R4KYUDzDRcmrxQ",
+    "value": "'lizards use to be dinosaurs, untill Chuck Norris kicked the height outta them'."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.480041",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "JyOoOwUYSY22fo0NN3qGFQ",
+    "updated_at": "2020-01-05 13:42:30.480041",
+    "url": "https://api.chucknorris.io/jokes/JyOoOwUYSY22fo0NN3qGFQ",
+    "value": "a man once heard two guys talking about Chuck Norris.He went home and decided to look up who Chuck Norris is? He was suprised when it came to a blank screen, he tryed to click out of it untill a window popped up please wait. He waited a while a bar appeared saying now uploading Chuck Norris.He looked stuned when Chuck Norris crawled out of his computer to round house kick him in the face. this man now knows every fact about Chuck Norris."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "3H2BXOGoSzCW4eJWRwbl5w",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/3H2BXOGoSzCW4eJWRwbl5w",
+    "value": "Chuck Norris roundhouse kicked micheal jackson so hard he flew across earth and came back white with his hair burning :)"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "9-ZDYtuDTIabrpNWObWdlQ",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/9-ZDYtuDTIabrpNWObWdlQ",
+    "value": "Chuck Norris once roundhouse kicked somebody into outer space...and died"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "1jLoBSXRRiKR9NkbuwmbnQ",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/1jLoBSXRRiKR9NkbuwmbnQ",
+    "value": "A blind man once stepped on Chuck Norris's shoe,chuck replied 'don't you know who I am I'm Chuck Norris, the sheer mention of his name cured the blindness of the man,but unfortunately for him the first,last an only thing the man sore was a fatal round house kick delivered by chuck."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "BBBGWLn5QqKWOapyxz1bXQ",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/BBBGWLn5QqKWOapyxz1bXQ",
+    "value": "meteors, there is no such thing those are the victims that being roundhouse kicked by Chuck Norris"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "2y2rXu3nRJ-rqO5kTXzMCg",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/2y2rXu3nRJ-rqO5kTXzMCg",
+    "value": "the grim reaper once was on Chuck Norris' door step. after he knocked, Chuck Norris said \"who is it\" the reaper responded \"death\" Chuck Norris chuckled and replied \"no its not! I am death!\" and proceeded to round house kick the reaper to death"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "jSO2ckHlS9WuibSd0Sob_g",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/jSO2ckHlS9WuibSd0Sob_g",
+    "value": "in soviet russia, Chuck Norris still kicks but!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "KqN1saMVRNutSewsBsxj1g",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/KqN1saMVRNutSewsBsxj1g",
+    "value": "Chuck Norris' roundhouse kick cures the common cold. its to bad nobody has ever survived one of his kicks before."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "lGgiaMRxS6OLN2ThemQxWA",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/lGgiaMRxS6OLN2ThemQxWA",
+    "value": "Mr johnson is the only one who can overtake Chuck Norris in a moped race. Chuck Norris then dropkicked him continusly and killed him."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "mvX9IOmGSNOa3pmIssRlIA",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/mvX9IOmGSNOa3pmIssRlIA",
+    "value": "we all know that the hulk is green..with envy, because he knows Chuck Norris can kick his fucking ass"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gcGgxFH7QDCcZabs9TLd5w",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/gcGgxFH7QDCcZabs9TLd5w",
+    "value": "In his spare time Chuck Norris likes to practice roundhouse kicks in corn fields, This is why we have crop circles!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "upDlt6ADSnidqIec498hVg",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/upDlt6ADSnidqIec498hVg",
+    "value": "When Chuck Norris died so did the music, so Chuck Norris gave music a round house kick to the head, music has never died since"
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "cYkYHCaIRMGMZJhCHqMiYA",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/cYkYHCaIRMGMZJhCHqMiYA",
+    "value": "Chuck Norris' penis can roundhouse kick the inside of a vagina"
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "IjGEWO0_TOOHiOjBEpnoGA",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/IjGEWO0_TOOHiOjBEpnoGA",
+    "value": "did you ever notice that quidditch rhymes with spinach so harry potter is actually Popeye and we all know Popeye is actually Chuck Norris's penis so by that logic Chuck Norris's penis eats spinach flexes, and avada-round house kicks you in the face!"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "kh2dFDFJRh22lt0PXUFlRQ",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/kh2dFDFJRh22lt0PXUFlRQ",
+    "value": "Chuck Norris could order a steak at PETA's cafeteria and get one. But he's far more likely to kick the shit out of all the candy-asses in the place before roundhousing the building into rubble."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "M_Q_uPxtQs-MVZ_RvhcktA",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/M_Q_uPxtQs-MVZ_RvhcktA",
+    "value": "Chuck Norris only drives American cars & he'll roundhouse kick the shit out of you if you don't. *if you put negative you drive a foreign car & don't support America *if you put positive you believe that America is and will always be the best country & that you support the American dream 100%"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "ktCzo7lgRQS6BZ9581vhQA",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/ktCzo7lgRQS6BZ9581vhQA",
+    "value": "Chuck Norris has a million Espurr. When they hug his legs, you better get the bleep out of there, or else you'll die a death worse than a normal Chuck Norris roundhouse kick. Don't believe me? Have you even READ Espurr's Pokedex entries?"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "JQkuvX5KSbyZ6KV9QS3nKQ",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/JQkuvX5KSbyZ6KV9QS3nKQ",
+    "value": "Question: Which of the following is most likely to occur? a) Having a threesome with two hot women b) Winning the lottery c) Discovering $10 billion of gold d) Kicking Chuck Norris' ass Answer: Don't know about the first three, but it's sure as shit that \"d\" will NEVER fucking happen."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "eci4mv88RJ6sTgIrsUMzoA",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/eci4mv88RJ6sTgIrsUMzoA",
+    "value": "At the dawn of time, Chuck Norris and Mr. T sat in an empty universe, bored with nothing to destroy, so they decided to arm wrestle. The competition began - it raged on for days and days, with thunderclaps of pure energy jolting off of their bulging muscles, ripping holes through reality, and creating the universe as we know it. Finally, after much-ado, and with one emphatic thud, Mr. T beat Chuck Norris at arm wrestling... ...And thus, Chuck Norris invented racism, and roundhouse kicked Mr. T into a bad 1980's TV show."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "7kUAskQpTAmiCyLL-2Djnw",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/7kUAskQpTAmiCyLL-2Djnw",
+    "value": "It's said that if you place Volume One of \"How To Roundhouse Kick Like Chuck Norris\" on a pregnant woman's stomach, her babies will grow up to be expert bodyguards AND 10683-degree black belts. By the way, only Vol. 13 is in less than 10 libraries. Why? It only contains a picture of Chuck Norris performing a roundhouse kick, which in turn roundhouse-kicks the reader. Few did not need to go to the hospital AND lived. Most of the others survived due to a trip to the hospital. The other readers died due to the picture."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "NHbyWimRQde4LYaDetooBQ",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/NHbyWimRQde4LYaDetooBQ",
+    "value": "You know that scene in Superman where Superman flies around the Earth to reverse it's spin and send time backwards? If you watch it frame by frame you will see a disappointed Chuck Norris at the North Pole shaking his head when he realizes that Superman is trying to do something impossible for a mere mortal of Krypton. But to help a brother out, Chuck Norris lets Superman get up to speed and roundhouse kicks the Earth to reverse the spin. He never did tell Superman the truth....mostly because he was still banging Lois Lane."
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "EVZV2ZbIT32UD0zTB-RE6Q",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/EVZV2ZbIT32UD0zTB-RE6Q",
+    "value": "How many Chuck Norris' roundhouse kick does it take for a nuclear explosion? 2"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "tTYSGkVLReiwoyZxCpRuBQ",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/tTYSGkVLReiwoyZxCpRuBQ",
+    "value": "quick how do u spell Chuck Norris .............. in that time you would already be dead by a roundhouse kick to the face twenty times before you get to c"
+  }, {
+    "categories": [],
+    "created_at": "2020-01-05 13:42:30.730109",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "bFnEmohIQimOR3ZVK3RNaQ",
+    "updated_at": "2020-01-05 13:42:30.730109",
+    "url": "https://api.chucknorris.io/jokes/bFnEmohIQimOR3ZVK3RNaQ",
+    "value": "AMFG@!@!@!! JESUSSS I GOT MU ASSS KICKED BY YO MOMA AHWDEAQHw3btr0gn94bgirubguibrgiubeuibgr GO CHUCK YEAAAAAA :) one day Chuck Norris was walking along the street and he wanted some marmite and it tasted real good! then he tried it on some toast and had a real big fright"
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:20.568859",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "o6hnjjOITzehqLHbSWS8hQ",
+    "updated_at": "2020-03-08 16:38:30.063749",
+    "url": "https://api.chucknorris.io/jokes/o6hnjjOITzehqLHbSWS8hQ",
+    "value": "Late at night, Chuck Norris was once walking back home alone after watching a Chuck Norris movie. A mugger approached him from the back, tapped on his shoulder and said \"Hey, gimme your money!\". Chuck Norris slowly turned around, paused for a while and gave the mugger a sarcastic smile. He then proceeded to rape the mugger anally, crush his skull, break his spine and killed him in a fraction of a second. Chuck Norris then brought the mugger back to life and then broke each of his limbs, eviscerated the mugger's gut, ate the mugger's still beating heart and infected him with AIDS, killing the unfortunate mugger once again. Chuck Norris then brough the mugger to life yet again for the second time, only to give the mugger a final fatal roundhous kick to his face killing the man and his soul at the same time. Chuck Norris then threw his packed wallet at the remains of his victim and said \"Do not tap on my shoulders ever again\", and continued to walk home slowly."
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:26.194739",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "lGPOoG2TRQydc8EItYlKng",
+    "updated_at": "2020-03-08 16:38:30.063749",
+    "url": "https://api.chucknorris.io/jokes/lGPOoG2TRQydc8EItYlKng",
+    "value": "When observing a Chuck Norris roundhouse kick in slow motion, one finds that Chuck Norris actually rapes his victim in the ass, smokes a cigarette with Dennis Leary, and then roundhouse kicks them in the face."
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:29.855523",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "gTzgfuNXQG-qtwDDqweeXQ",
+    "updated_at": "2020-03-08 16:38:30.063749",
+    "url": "https://api.chucknorris.io/jokes/gTzgfuNXQG-qtwDDqweeXQ",
+    "value": "Chuck Norris once got confused by looking at the infinity sign, so he roundhouse kicked it back into a clock, he now has it straped onto his wrist and calls it his wristwatch"
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:29.296379",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "i4zAxwdGQ5OIY1wBHNZ6zQ",
+    "updated_at": "2020-03-08 16:38:30.063749",
+    "url": "https://api.chucknorris.io/jokes/i4zAxwdGQ5OIY1wBHNZ6zQ",
+    "value": "Chuck Norris owns a chain of toilet companies. When someone used them, instead of taking shit from someone, a foot comes up and ass- rapes them, followed by a roundhouse kick to the face. Nobody ever had the courage to use those toilets again (unless Chuck Norris forces them to!!!!)."
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:20.841843",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "SVdvBhI6RZudJ5Lq8C9YGw",
+    "updated_at": "2020-03-08 16:38:30.063749",
+    "url": "https://api.chucknorris.io/jokes/SVdvBhI6RZudJ5Lq8C9YGw",
+    "value": "In Left 4 Dead: If you startle the witch she runs to you and kills you. If Chuck norris startle the witch she tries to run away but always ends up being raped and roundhouse kicked to death"
+  }, {
+    "categories": ["explicit"],
+    "created_at": "2020-01-05 13:42:29.569033",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "FFGg0jRGTVqJEDM1dLuSWw",
+    "updated_at": "2020-03-08 16:38:30.063749",
+    "url": "https://api.chucknorris.io/jokes/FFGg0jRGTVqJEDM1dLuSWw",
+    "value": "The official CIA report reads, \"Chuck Norris impaled Osama bin Laden with a flame, raped all 54 of his wives for 126 minutes, then roundhouse kicked his son in the soul. His son reached approximately 1 million degrees Fahrenheit in less than a second."
+  }, {
+    "categories": ["food"],
+    "created_at": "2020-01-05 13:42:19.324003",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "uIrcWG7dRQG2SE2ZITAldQ",
+    "updated_at": "2020-05-22 06:02:41.792421",
+    "url": "https://api.chucknorris.io/jokes/uIrcWG7dRQG2SE2ZITAldQ",
+    "value": "Pepis was created when Chuck Norris said i want a Drink and not a Coke they owe me money. Pepis was thought of, invented, created, canned, and brought to Chuck Norris in 12 mins. Chuck Norris still roundhouse kicked the delivery guy for being to slow with his drink"
+  }, {
+    "categories": ["money"],
+    "created_at": "2020-01-05 13:42:23.880601",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "i6l180dNSiW4AvAxQcBERg",
+    "updated_at": "2020-05-22 06:16:41.133769",
+    "url": "https://api.chucknorris.io/jokes/i6l180dNSiW4AvAxQcBERg",
+    "value": "NASA wants to save money so they asked Chuck Norris to kick the rockets into space and he tied a rope to the rocket to pull it back."
+  }, {
+    "categories": ["money"],
+    "created_at": "2020-01-05 13:42:26.447675",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "13urACbrRw6YBc7Fr3d7wA",
+    "updated_at": "2020-05-22 06:16:41.133769",
+    "url": "https://api.chucknorris.io/jokes/13urACbrRw6YBc7Fr3d7wA",
+    "value": "Body armor: $2999.99 Missile launcher: $50,000.99 Getting roundhouse kicked after hitting Chuck Norris with a missile and having body armor, missile launcher and your very being disintegrate on impact: priceless. There are some things money can't buy, a life free from the constant fear of Chuck Norris is one of them."
+  }, {
+    "categories": ["money"],
+    "created_at": "2020-01-05 13:42:26.766831",
+    "icon_url": "https://assets.chucknorris.host/img/avatar/chuck-norris.png",
+    "id": "5cGCv-UkQR6S7HeRjULwyw",
+    "updated_at": "2020-05-22 06:16:41.133769",
+    "url": "https://api.chucknorris.io/jokes/5cGCv-UkQR6S7HeRjULwyw",
+    "value": "When Chuck Norris played golf for money, chuck marked down a hole in 0 every time, a pro at the golf club, said to Chuck: \"excuse me sir, but you cant score zero on a hole\". Chuck Norris turned towards the man and said, im Chuck Norris, the man then proceeded to pour gas over his body and set himself on fire because that would be less painful than getting roundhouse kicked by Chuck Norris, Chuck Norris roundhouse kicked him in the face anyways."
+  }]
+}


### PR DESCRIPTION
This PR adds
- Benchmark case for simple and complex object
- Composer script to start the benchmark using `composer benchmark`

Outcome of the benchmark is:
```
+------+-----------------+-----------------------+-----+------+------------+---------------+--------------+----------------+
| iter | benchmark       | subject               | set | revs | mem_peak   | time_avg      | comp_z_value | comp_deviation |
+------+-----------------+-----------------------+-----+------+------------+---------------+--------------+----------------+
| 0    | JsonMapperBench | benchMapSimpleObject  | 0   | 100  | 7,506,144b | 309.660μs     | -0.35σ       | -1.47%         |
| 1    | JsonMapperBench | benchMapSimpleObject  | 0   | 100  | 7,506,144b | 327.930μs     | +1.03σ       | +4.34%         |
| 2    | JsonMapperBench | benchMapSimpleObject  | 0   | 100  | 7,506,144b | 306.780μs     | -0.57σ       | -2.39%         |
| 3    | JsonMapperBench | benchMapSimpleObject  | 0   | 100  | 7,506,144b | 296.030μs     | -1.38σ       | -5.81%         |
| 4    | JsonMapperBench | benchMapSimpleObject  | 0   | 100  | 7,506,144b | 331.030μs     | +1.26σ       | +5.33%         |
| 0    | JsonMapperBench | benchMapComplexObject | 0   | 100  | 8,722,880b | 152,858.930μs | -0.37σ       | -2.51%         |
| 1    | JsonMapperBench | benchMapComplexObject | 0   | 100  | 8,722,880b | 147,060.120μs | -0.91σ       | -6.21%         |
| 2    | JsonMapperBench | benchMapComplexObject | 0   | 100  | 8,722,880b | 177,644.650μs | +1.95σ       | +13.29%        |
| 3    | JsonMapperBench | benchMapComplexObject | 0   | 100  | 8,722,880b | 153,541.150μs | -0.31σ       | -2.08%         |
| 4    | JsonMapperBench | benchMapComplexObject | 0   | 100  | 8,722,880b | 152,904.000μs | -0.36σ       | -2.49%         |
+------+-----------------+-----------------------+-----+------+------------+---------------+--------------+----------------+

```