### PR TITLE
Add global namespace separator; Optimze enum usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Invoke PHP native functions with fq namespace to improve speed. [PR#100](https://github.com/JsonMapper/JsonMapper/pull/100)
 
 ## [2.6.0] - 2021-07-15
 ### Added 

--- a/src/Cache/ArrayCache.php
+++ b/src/Cache/ArrayCache.php
@@ -47,7 +47,7 @@ class ArrayCache implements CacheInterface
 
         $values = [];
         $keys = (array) $keys;
-        array_walk($keys, function ($key) use ($default, &$values) {
+        \array_walk($keys, function ($key) use ($default, &$values) {
             $values[$key] = $this->cache[$key] ?? $default;
         });
 
@@ -56,14 +56,14 @@ class ArrayCache implements CacheInterface
 
     public function setMultiple($values, $ttl = null): bool
     {
-        if (! is_iterable($values)) {
+        if (! \is_iterable($values)) {
             throw InvalidArgumentException::forCacheKey($values);
         }
 
         $values = (array) $values;
         self::ensureKeyArgumentIsValidSetOfKeys(array_keys($values));
 
-        $this->cache = array_merge($this->cache, $values);
+        $this->cache = \array_merge($this->cache, $values);
 
         return true;
     }
@@ -73,7 +73,7 @@ class ArrayCache implements CacheInterface
         self::ensureKeyArgumentIsValidSetOfKeys($keys);
 
         $keys = (array) $keys;
-        array_walk($keys, function ($key) {
+        \array_walk($keys, function ($key) {
             unset($this->cache[$key]);
         });
 
@@ -87,7 +87,7 @@ class ArrayCache implements CacheInterface
     {
         self::ensureKeyArgumentIsValidSingleKey($key);
 
-        return array_key_exists($key, $this->cache);
+        return \array_key_exists($key, $this->cache);
     }
 
     /**
@@ -95,7 +95,7 @@ class ArrayCache implements CacheInterface
      */
     private static function ensureKeyArgumentIsValidSingleKey($key): void
     {
-        if (is_string($key)) {
+        if (\is_string($key)) {
             return;
         }
 
@@ -107,12 +107,12 @@ class ArrayCache implements CacheInterface
      */
     private static function ensureKeyArgumentIsValidSetOfKeys($keys): void
     {
-        if (! is_iterable($keys)) {
+        if (! \is_iterable($keys)) {
             throw InvalidArgumentException::forCacheKey($keys);
         }
 
         $keys = (array) $keys;
-        array_walk($keys, static function ($key) {
+        \array_walk($keys, static function ($key) {
             self::ensureKeyArgumentIsValidSingleKey($key);
         });
     }

--- a/src/Cache/NullCache.php
+++ b/src/Cache/NullCache.php
@@ -28,14 +28,14 @@ class NullCache implements CacheInterface
 
     public function getMultiple($keys, $default = null)
     {
-        if (! is_iterable($keys)) {
+        if (! \is_iterable($keys)) {
             throw InvalidArgumentException::forCacheKey($keys);
         }
 
         $keys = (array) $keys;
-        $values = array_fill(0, count($keys), $default);
+        $values = \array_fill(0, count($keys), $default);
 
-        return (array) array_combine($keys, $values);
+        return (array) \array_combine($keys, $values);
     }
 
     public function setMultiple($values, $ttl = null): bool

--- a/src/Enums/ScalarType.php
+++ b/src/Enums/ScalarType.php
@@ -28,25 +28,25 @@ class ScalarType extends Enum
     protected const MIXED = 'mixed';
 
     /**
-     * @param string|bool|int|float $value
+     * @param string|bool|int|float $input
      * @return string|bool|int|float
      */
-    public function cast($value)
+    public function cast($input)
     {
-        if ($this->equals(self::MIXED())) {
-            return $value;
+        if ($this->value === self::MIXED) {
+            return $input;
         }
-        if ($this->equals(self::STRING())) {
-            return (string) $value;
+        if ($this->value === self::STRING) {
+            return (string) $input;
         }
-        if ($this->equals(self::BOOLEAN()) || $this->equals(self::BOOL())) {
-            return (bool) $value;
+        if ($this->value === self::BOOLEAN || $this->value === self::BOOL) {
+            return (bool) $input;
         }
-        if ($this->equals(self::INTEGER()) || $this->equals(self::INT())) {
-            return (int) $value;
+        if ($this->value === self::INTEGER || $this->value === self::INT) {
+            return (int) $input;
         }
-        if ($this->equals(self::DOUBLE()) || $this->equals(self::FLOAT())) {
-            return (float) $value;
+        if ($this->value === self::DOUBLE || $this->value === self::FLOAT) {
+            return (float) $input;
         }
 
         throw new \LogicException("Missing {$this->value} in cast method");

--- a/src/Exception/TypeError.php
+++ b/src/Exception/TypeError.php
@@ -9,8 +9,8 @@ class TypeError extends \TypeError
     /** @param mixed $object */
     public static function forObjectArgument(string $method, $object, int $argumentNumber): TypeError
     {
-        $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
-        return new TypeError(sprintf(
+        $trace = \debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
+        return new TypeError(\sprintf(
             '%s(): Argument #%d ($object) must be of type object, %s given, called in %s on line %d',
             $method,
             $argumentNumber,

--- a/src/Handler/FactoryRegistry.php
+++ b/src/Handler/FactoryRegistry.php
@@ -40,7 +40,7 @@ class FactoryRegistry
 
     public function hasFactory(string $className): bool
     {
-        return array_key_exists($this->sanitiseClassName($className), $this->factories);
+        return \array_key_exists($this->sanitiseClassName($className), $this->factories);
     }
 
     /**
@@ -61,8 +61,8 @@ class FactoryRegistry
     private function sanitiseClassName(string $className): string
     {
         /* Erase leading slash as ::class doesnt contain leading slash */
-        if (strpos($className, '\\') === 0) {
-            $className = substr($className, 1);
+        if (\strpos($className, '\\') === 0) {
+            $className = \substr($className, 1);
         }
 
         return $className;

--- a/src/Helpers/ClassHelper.php
+++ b/src/Helpers/ClassHelper.php
@@ -11,7 +11,7 @@ class ClassHelper
 {
     public static function isBuiltin(string $type): bool
     {
-        if ($type === 'mixed' || ScalarType::isValid($type) || !class_exists($type)) {
+        if ($type === 'mixed' || ScalarType::isValid($type) || ! \class_exists($type)) {
             return false;
         }
 
@@ -21,7 +21,7 @@ class ClassHelper
 
     public static function isCustom(string $type): bool
     {
-        if ($type === 'mixed' || ScalarType::isValid($type) || !class_exists($type)) {
+        if ($type === 'mixed' || ScalarType::isValid($type) || ! \class_exists($type)) {
             return false;
         }
 

--- a/src/Helpers/UseStatementHelper.php
+++ b/src/Helpers/UseStatementHelper.php
@@ -20,15 +20,15 @@ class UseStatementHelper
         }
 
         $filename = $class->getFileName();
-        if ($filename === false || substr($filename, -13) === self::$evaldCodeFileNameEnding) {
+        if ($filename === false || \substr($filename, -13) === self::$evaldCodeFileNameEnding) {
             throw new \RuntimeException("Class {$class->getName()} has no filename available");
         }
 
-        if (!is_readable($filename)) {
+        if (! \is_readable($filename)) {
             throw new \RuntimeException("Unable to read {$class->getFileName()}");
         }
 
-        $contents = file_get_contents($filename);
+        $contents = \file_get_contents($filename);
         if ($contents === false) {
             throw new \RuntimeException("Unable to read {$class->getFileName()}");
         }

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -42,7 +42,7 @@ class JsonMapper implements JsonMapperInterface
 
     public function pop(): JsonMapperInterface
     {
-        array_pop($this->stack);
+        \array_pop($this->stack);
         $this->cached = null;
 
         return $this;
@@ -50,7 +50,7 @@ class JsonMapper implements JsonMapperInterface
 
     public function unshift(callable $middleware, string $name = ''): JsonMapperInterface
     {
-        array_unshift($this->stack, new NamedMiddleware($middleware, $name));
+        \array_unshift($this->stack, new NamedMiddleware($middleware, $name));
         $this->cached = null;
 
         return $this;
@@ -58,7 +58,7 @@ class JsonMapper implements JsonMapperInterface
 
     public function shift(): JsonMapperInterface
     {
-        array_shift($this->stack);
+        \array_shift($this->stack);
         $this->cached = null;
 
         return $this;
@@ -66,7 +66,7 @@ class JsonMapper implements JsonMapperInterface
 
     public function remove(callable $remove): JsonMapperInterface
     {
-        $this->stack = array_values(array_filter(
+        $this->stack = \array_values(\array_filter(
             $this->stack,
             static function (NamedMiddleware $namedMiddleware) use ($remove) {
                 return $namedMiddleware->getMiddleware() !== $remove;
@@ -79,7 +79,7 @@ class JsonMapper implements JsonMapperInterface
 
     public function removeByName(string $remove): JsonMapperInterface
     {
-        $this->stack = array_values(array_filter(
+        $this->stack = \array_values(\array_filter(
             $this->stack,
             static function (NamedMiddleware $namedMiddleware) use ($remove) {
                 return $namedMiddleware->getName() !== $remove;
@@ -93,7 +93,7 @@ class JsonMapper implements JsonMapperInterface
     /** @param object $object */
     public function mapObject(\stdClass $json, $object): void
     {
-        if (!is_object($object)) {
+        if (! \is_object($object)) {
             throw TypeError::forObjectArgument(__METHOD__, $object, 2);
         }
 
@@ -106,7 +106,7 @@ class JsonMapper implements JsonMapperInterface
     /** @param object $object */
     public function mapArray(array $json, $object): array
     {
-        if (!is_object($object)) {
+        if (! \is_object($object)) {
             throw TypeError::forObjectArgument(__METHOD__, $object, 2);
         }
 
@@ -122,7 +122,7 @@ class JsonMapper implements JsonMapperInterface
     /** @param object $object */
     public function mapObjectFromString(string $json, $object): void
     {
-        if (!is_object($object)) {
+        if (! \is_object($object)) {
             throw TypeError::forObjectArgument(__METHOD__, $object, 2);
         }
 
@@ -138,13 +138,13 @@ class JsonMapper implements JsonMapperInterface
     /** @param object $object */
     public function mapArrayFromString(string $json, $object): array
     {
-        if (!is_object($object)) {
+        if (! \is_object($object)) {
             throw TypeError::forObjectArgument(__METHOD__, $object, 2);
         }
 
         $data = $this->decodeJsonString($json);
 
-        if (! is_array($data)) {
+        if (! \is_array($data)) {
             throw new \RuntimeException('Provided string is not a json encoded array');
         }
 
@@ -161,11 +161,11 @@ class JsonMapper implements JsonMapperInterface
     private function decodeJsonString(string $json)
     {
         if (PHP_VERSION_ID >= 70300) {
-            $data = json_decode($json, false, 512, JSON_THROW_ON_ERROR);
+            $data = \json_decode($json, false, 512, JSON_THROW_ON_ERROR);
         } else {
-            $data = json_decode($json, false);
-            if (json_last_error() !== JSON_ERROR_NONE) {
-                throw new JsonException(json_last_error_msg(), json_last_error());
+            $data = \json_decode($json, false);
+            if (\json_last_error() !== JSON_ERROR_NONE) {
+                throw new \JsonException(json_last_error_msg(), \json_last_error());
             }
         }
 
@@ -176,7 +176,7 @@ class JsonMapper implements JsonMapperInterface
     {
         if (!$this->cached) {
             $prev = $this->propertyMapper;
-            foreach (array_reverse($this->stack) as $namedMiddleware) {
+            foreach (\array_reverse($this->stack) as $namedMiddleware) {
                 $prev = $namedMiddleware->getMiddleware()($prev);
             }
 

--- a/src/Middleware/CaseConversion.php
+++ b/src/Middleware/CaseConversion.php
@@ -32,7 +32,7 @@ class CaseConversion extends AbstractMiddleware
             return;
         }
 
-        $keys = array_keys((array) $json);
+        $keys = \array_keys((array) $json);
         foreach ($keys as $key) {
             $replacementKey = $this->getReplacementKey($key);
 
@@ -65,11 +65,11 @@ class CaseConversion extends AbstractMiddleware
     {
         switch ($this->replacementSeparator) {
             case TextNotation::STUDLY_CAPS():
-                return ucfirst($key);
+                return \ucfirst($key);
             case TextNotation::UNDERSCORE():
-                return strtolower((string) preg_replace('/(?<!^)[A-Z]/', '_$0', $key));
+                return \strtolower((string) \preg_replace('/(?<!^)[A-Z]/', '_$0', $key));
             case TextNotation::KEBAB_CASE():
-                return strtolower((string) preg_replace('/(?<!^)[A-Z]/', '-$0', $key));
+                return \strtolower((string) \preg_replace('/(?<!^)[A-Z]/', '-$0', $key));
             case TextNotation::CAMEL_CASE():
             default:
                 return $key;
@@ -80,11 +80,11 @@ class CaseConversion extends AbstractMiddleware
     {
         switch ($this->replacementSeparator) {
             case TextNotation::CAMEL_CASE():
-                return lcfirst($key);
+                return \lcfirst($key);
             case TextNotation::UNDERSCORE():
-                return strtolower((string) preg_replace('/(?<!^)[A-Z]/', '_$0', $key));
+                return \strtolower((string) \preg_replace('/(?<!^)[A-Z]/', '_$0', $key));
             case TextNotation::KEBAB_CASE():
-                return strtolower((string) preg_replace('/(?<!^)[A-Z]/', '-$0', $key));
+                return \strtolower((string) \preg_replace('/(?<!^)[A-Z]/', '-$0', $key));
             case TextNotation::STUDLY_CAPS():
             default:
                 return $key;
@@ -95,11 +95,11 @@ class CaseConversion extends AbstractMiddleware
     {
         switch ($this->replacementSeparator) {
             case TextNotation::STUDLY_CAPS():
-                return ucfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $key))));
+                return \ucfirst(\str_replace(' ', '', \ucwords(\str_replace('_', ' ', $key))));
             case TextNotation::CAMEL_CASE():
-                return lcfirst(str_replace(' ', '', ucwords(str_replace('_', ' ', $key))));
+                return lcfirst(\str_replace(' ', '', \ucwords(\str_replace('_', ' ', $key))));
             case TextNotation::KEBAB_CASE():
-                return str_replace('_', '-', $key);
+                return \str_replace('_', '-', $key);
             case TextNotation::UNDERSCORE():
             default:
                 return $key;
@@ -110,11 +110,11 @@ class CaseConversion extends AbstractMiddleware
     {
         switch ($this->replacementSeparator) {
             case TextNotation::STUDLY_CAPS():
-                return ucfirst(str_replace(' ', '', ucwords(str_replace('-', ' ', $key))));
+                return \ucfirst(\str_replace(' ', '', \ucwords(\str_replace('-', ' ', $key))));
             case TextNotation::CAMEL_CASE():
-                return lcfirst(str_replace(' ', '', ucwords(str_replace('-', ' ', $key))));
+                return \lcfirst(\str_replace(' ', '', \ucwords(\str_replace('-', ' ', $key))));
             case TextNotation::UNDERSCORE():
-                return str_replace('-', '_', $key);
+                return \str_replace('-', '_', $key);
             case TextNotation::KEBAB_CASE():
             default:
                 return $key;

--- a/src/Middleware/Debugger.php
+++ b/src/Middleware/Debugger.php
@@ -28,8 +28,8 @@ class Debugger extends AbstractMiddleware
         $this->logger->debug(
             'Current state attributes passed through JsonMapper middleware',
             [
-                'json' => json_encode($json),
-                'object' => get_class($object->getObject()),
+                'json' => \json_encode($json),
+                'object' => \get_class($object->getObject()),
                 'propertyMap' => $propertyMap->toString()
             ]
         );

--- a/src/Middleware/DocBlockAnnotations.php
+++ b/src/Middleware/DocBlockAnnotations.php
@@ -35,7 +35,7 @@ class DocBlockAnnotations extends AbstractMiddleware
 
     private function fetchPropertyMapForObject(ObjectWrapper $object): PropertyMap
     {
-        $cacheKey = sprintf('%s::Cache::%s', __CLASS__, $object->getName());
+        $cacheKey = \sprintf('%s::Cache::%s', __CLASS__, $object->getName());
         if ($this->cache->has($cacheKey)) {
             return $this->cache->get($cacheKey);
         }
@@ -56,9 +56,9 @@ class DocBlockAnnotations extends AbstractMiddleware
                 continue;
             }
 
-            $types = explode('|', $annotations->getVar());
-            $nullable = in_array('null', $types, true);
-            $types = array_filter($types, static function (string $type) {
+            $types = \explode('|', $annotations->getVar());
+            $nullable = \in_array('null', $types, true);
+            $types = \array_filter($types, static function (string $type) {
                 return $type !== 'null';
             });
 
@@ -68,17 +68,17 @@ class DocBlockAnnotations extends AbstractMiddleware
                 ->setVisibility(Visibility::fromReflectionProperty($property));
 
             /* A union type that has one of its types defined as array is to complex to understand */
-            if (in_array('array', $types, true)) {
+            if (\in_array('array', $types, true)) {
                 $property = $builder->addType('mixed', true)->build();
                 $intermediatePropertyMap->addProperty($property);
                 continue;
             }
 
             foreach ($types as $type) {
-                $type = trim($type);
-                $isArray = substr($type, -2) === '[]';
+                $type = \trim($type);
+                $isArray = \substr($type, -2) === '[]';
                 if ($isArray) {
-                    $type = substr($type, 0, -2);
+                    $type = \substr($type, 0, -2);
                 }
                 $builder->addType($type, $isArray);
             }
@@ -96,15 +96,15 @@ class DocBlockAnnotations extends AbstractMiddleware
     {
         // Strip away the start "/**' and ending "*/"
         if (strpos($docBlock, '/**') === 0) {
-            $docBlock = substr($docBlock, 3);
+            $docBlock = \substr($docBlock, 3);
         }
         if (substr($docBlock, -2) === '*/') {
-            $docBlock = substr($docBlock, 0, -2);
+            $docBlock = \substr($docBlock, 0, -2);
         }
-        $docBlock = trim($docBlock);
+        $docBlock = \trim($docBlock);
 
         $var = null;
-        if (preg_match_all(self::DOC_BLOCK_REGEX, $docBlock, $matches)) {
+        if (\preg_match_all(self::DOC_BLOCK_REGEX, $docBlock, $matches)) {
             for ($x = 0, $max = count($matches[0]); $x < $max; $x++) {
                 if ($matches['name'][$x] === 'var') {
                     $var = $matches['value'][$x];

--- a/src/Middleware/FinalCallback.php
+++ b/src/Middleware/FinalCallback.php
@@ -39,7 +39,7 @@ class FinalCallback implements MiddlewareInterface
             self::$nestingLevel--;
 
             if (! $this->onlyApplyCallBackOnTopLevel || self::$nestingLevel === 0) {
-                call_user_func($this->callback, $json, $object, $map, $mapper);
+                \call_user_func($this->callback, $json, $object, $map, $mapper);
             }
         };
     }

--- a/src/Middleware/NamespaceResolver.php
+++ b/src/Middleware/NamespaceResolver.php
@@ -38,7 +38,7 @@ class NamespaceResolver extends AbstractMiddleware
 
     private function fetchPropertyMapForObject(ObjectWrapper $object, PropertyMap $originalPropertyMap): PropertyMap
     {
-        $cacheKey = sprintf('%s::Cache::%s', __CLASS__, $object->getName());
+        $cacheKey = \sprintf('%s::Cache::%s', __CLASS__, $object->getName());
         if ($this->cache->has($cacheKey)) {
             return $this->cache->get($cacheKey);
         }
@@ -66,15 +66,15 @@ class NamespaceResolver extends AbstractMiddleware
             return $type;
         }
 
-        $matches = array_filter(
+        $matches = \array_filter(
             $imports,
             static function (string $import) use ($type) {
-                return $type->getType() === substr($import, -1 * strlen($type->getType()));
+                return $type->getType() === \substr($import, -1 * \strlen($type->getType()));
             }
         );
 
         if (count($matches) > 0) {
-            return new PropertyType(array_shift($matches), $type->isArray());
+            return new PropertyType(\array_shift($matches), $type->isArray());
         }
 
         if (!class_exists($type->getType())) {

--- a/src/Middleware/Rename/Rename.php
+++ b/src/Middleware/Rename/Rename.php
@@ -30,8 +30,8 @@ class Rename extends AbstractMiddleware
         PropertyMap $propertyMap,
         JsonMapperInterface $mapper
     ): void {
-        $mapping = array_filter($this->mapping, static function ($map) use ($object) {
-            return $map->getClass() === get_class($object->getObject());
+        $mapping = \array_filter($this->mapping, static function ($map) use ($object) {
+            return $map->getClass() === \get_class($object->getObject());
         });
         foreach ($mapping as $map) {
             $from = $map->getFrom();

--- a/src/Middleware/TypedProperties.php
+++ b/src/Middleware/TypedProperties.php
@@ -35,7 +35,7 @@ class TypedProperties extends AbstractMiddleware
 
     private function fetchPropertyMapForObject(ObjectWrapper $object): PropertyMap
     {
-        $cacheKey = sprintf('%s::Cache::%s', __CLASS__, $object->getName());
+        $cacheKey = \sprintf('%s::Cache::%s', __CLASS__, $object->getName());
         if ($this->cache->has($cacheKey)) {
             return $this->cache->get($cacheKey);
         }
@@ -61,10 +61,10 @@ class TypedProperties extends AbstractMiddleware
             }
 
             if ($type instanceof ReflectionUnionType) {
-                $types = array_map(static function (ReflectionNamedType $t): string {
+                $types = \array_map(static function (ReflectionNamedType $t): string {
                     return $t->getName();
                 }, $type->getTypes());
-                $isArray = in_array('array', $types, true);
+                $isArray = \in_array('array', $types, true);
 
                 $builder = PropertyBuilder::new()
                     ->setName($reflectionProperty->getName())

--- a/src/ValueObjects/AnnotationMap.php
+++ b/src/ValueObjects/AnnotationMap.php
@@ -22,12 +22,12 @@ class AnnotationMap
 
     public function hasVar(): bool
     {
-        return ! is_null($this->var);
+        return ! \is_null($this->var);
     }
 
     public function getVar(): string
     {
-        if (is_null($this->var)) {
+        if (\is_null($this->var)) {
             throw new \Exception('Annotation map doesnt contain valid value for var');
         }
         return $this->var;
@@ -40,12 +40,12 @@ class AnnotationMap
 
     public function hasReturn(): bool
     {
-        return ! is_null($this->return);
+        return ! \is_null($this->return);
     }
 
     public function getReturn(): string
     {
-        if (is_null($this->return)) {
+        if (\is_null($this->return)) {
             throw new \Exception('Annotation map doesnt contain valid value for return');
         }
         return $this->return;

--- a/src/ValueObjects/Property.php
+++ b/src/ValueObjects/Property.php
@@ -53,7 +53,7 @@ class Property implements \JsonSerializable
 
     public function isUnion(): bool
     {
-        return count($this->propertyTypes) > 1;
+        return \count($this->propertyTypes) > 1;
     }
 
     public function asBuilder(): PropertyBuilder

--- a/src/ValueObjects/PropertyMap.php
+++ b/src/ValueObjects/PropertyMap.php
@@ -8,15 +8,18 @@ class PropertyMap implements \IteratorAggregate, \JsonSerializable
 {
     /** @var Property[] */
     private $map = [];
+    /** @var \ArrayIterator|null */
+    private $iterator = null;
 
     public function addProperty(Property $property): void
     {
         $this->map[$property->getName()] = $property;
+        $this->iterator = null;
     }
 
     public function hasProperty(string $name): bool
     {
-        return array_key_exists($name, $this->map);
+        return \array_key_exists($name, $this->map);
     }
 
     public function getProperty(string $key): Property
@@ -47,11 +50,16 @@ class PropertyMap implements \IteratorAggregate, \JsonSerializable
 
             $this->addProperty($builder->build());
         }
+        $this->iterator = null;
     }
 
     public function getIterator(): \ArrayIterator
     {
-        return new \ArrayIterator($this->map);
+        if (\is_null($this->iterator)) {
+            $this->iterator = new \ArrayIterator($this->map);
+        }
+
+        return $this->iterator;
     }
 
     public function jsonSerialize(): array
@@ -63,6 +71,6 @@ class PropertyMap implements \IteratorAggregate, \JsonSerializable
 
     public function toString(): string
     {
-        return (string) json_encode($this);
+        return (string) \json_encode($this);
     }
 }

--- a/src/Wrapper/ObjectWrapper.php
+++ b/src/Wrapper/ObjectWrapper.php
@@ -16,7 +16,7 @@ class ObjectWrapper
     /** @param object $object */
     public function __construct($object)
     {
-        if (!is_object($object)) {
+        if (! \is_object($object)) {
             throw TypeError::forObjectArgument(__METHOD__, $object, 1);
         }
 


### PR DESCRIPTION
This PR adds a leading slash on the PHP native functions and optimises the Enums used. 
Result from the benchmark show a significant improvement in time


**Develop:**
```
\JsonMapper\Tests\benchmark\JsonMapperBench

    benchMapSimpleObject....................I4 - Mo309.976μs (±20.94%)
    benchMapComplexObject...................I4 - Mo154.972ms (±2.86%)

Subjects: 2, Assertions: 0, Failures: 0, Errors: 0

+------+-----------------+-----------------------+-----+------+------------+---------------+--------------+----------------+
| iter | benchmark       | subject               | set | revs | mem_peak   | time_avg      | comp_z_value | comp_deviation |
+------+-----------------+-----------------------+-----+------+------------+---------------+--------------+----------------+
| 0    | JsonMapperBench | benchMapSimpleObject  | 0   | 100  | 7,506,144b | 490.050μs     | +2.00σ       | +41.80%        |
| 1    | JsonMapperBench | benchMapSimpleObject  | 0   | 100  | 7,506,144b | 317.380μs     | -0.39σ       | -8.16%         |
| 2    | JsonMapperBench | benchMapSimpleObject  | 0   | 100  | 7,506,144b | 304.530μs     | -0.57σ       | -11.88%        |
| 3    | JsonMapperBench | benchMapSimpleObject  | 0   | 100  | 7,506,144b | 308.280μs     | -0.52σ       | -10.79%        |
| 4    | JsonMapperBench | benchMapSimpleObject  | 0   | 100  | 7,506,144b | 307.680μs     | -0.52σ       | -10.97%        |
| 0    | JsonMapperBench | benchMapComplexObject | 0   | 100  | 8,723,568b | 157,751.430μs | +0.93σ       | +2.67%         |
| 1    | JsonMapperBench | benchMapComplexObject | 0   | 100  | 8,723,568b | 152,574.120μs | -0.24σ       | -0.70%         |
| 2    | JsonMapperBench | benchMapComplexObject | 0   | 100  | 8,723,568b | 158,704.770μs | +1.15σ       | +3.29%         |
| 3    | JsonMapperBench | benchMapComplexObject | 0   | 100  | 8,723,568b | 152,788.720μs | -0.19σ       | -0.56%         |
| 4    | JsonMapperBench | benchMapComplexObject | 0   | 100  | 8,723,568b | 146,398.890μs | -1.65σ       | -4.72%         |
+------+-----------------+-----------------------+-----+------+------------+---------------+--------------+----------------+
```
**This branch:**
```
\JsonMapper\Tests\benchmark\JsonMapperBench

    benchMapSimpleObject....................I4 - Mo268.478μs (±3.91%)
    benchMapComplexObject...................I4 - Mo130.912ms (±4.08%)

Subjects: 2, Assertions: 0, Failures: 0, Errors: 0

+------+-----------------+-----------------------+-----+------+------------+---------------+--------------+----------------+
| iter | benchmark       | subject               | set | revs | mem_peak   | time_avg      | comp_z_value | comp_deviation |
+------+-----------------+-----------------------+-----+------+------------+---------------+--------------+----------------+
| 0    | JsonMapperBench | benchMapSimpleObject  | 0   | 100  | 7,498,864b | 272.210μs     | -0.12σ       | -0.46%         |
| 1    | JsonMapperBench | benchMapSimpleObject  | 0   | 100  | 7,498,864b | 278.690μs     | +0.49σ       | +1.91%         |
| 2    | JsonMapperBench | benchMapSimpleObject  | 0   | 100  | 7,498,864b | 262.780μs     | -1.00σ       | -3.91%         |
| 3    | JsonMapperBench | benchMapSimpleObject  | 0   | 100  | 7,498,864b | 291.090μs     | +1.65σ       | +6.44%         |
| 4    | JsonMapperBench | benchMapSimpleObject  | 0   | 100  | 7,498,864b | 262.560μs     | -1.02σ       | -3.99%         |
| 0    | JsonMapperBench | benchMapComplexObject | 0   | 100  | 8,714,928b | 132,552.900μs | -0.17σ       | -0.70%         |
| 1    | JsonMapperBench | benchMapComplexObject | 0   | 100  | 8,714,928b | 131,502.920μs | -0.36σ       | -1.48%         |
| 2    | JsonMapperBench | benchMapComplexObject | 0   | 100  | 8,714,928b | 144,090.070μs | +1.95σ       | +7.95%         |
| 3    | JsonMapperBench | benchMapComplexObject | 0   | 100  | 8,714,928b | 128,750.600μs | -0.87σ       | -3.55%         |
| 4    | JsonMapperBench | benchMapComplexObject | 0   | 100  | 8,714,928b | 130,518.840μs | -0.54σ       | -2.22%         |
+------+-----------------+-----------------------+-----+------+------------+---------------+--------------+----------------+
```