### PR TITLE
Fix problems with mixing classes in the current namespaces and another.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - The value transformation middleware was added to apply a callback to the values of the json object [PR#111](https://github.com/JsonMapper/JsonMapper/pull/111) Thanks to [Philipp Dahse](https://github.com/dahse89)
+### Fixed
+- Namespace resolving was strengthened to avoid partial matches and now also includes support for using `alias` in `use` statements [PR#112](https://github.com/JsonMapper/JsonMapper/pull/112) Thanks to [Christopher Reimer](https://github.com/CReimer)
 
 ## [2.8.0] - 2021-10-05
 ### Added

--- a/src/Helpers/UseStatementHelper.php
+++ b/src/Helpers/UseStatementHelper.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JsonMapper\Helpers;
 
+use JsonMapper\Parser\Import;
 use JsonMapper\Parser\UseNodeVisitor;
 use PhpParser\NodeTraverser;
 use PhpParser\ParserFactory;
@@ -13,6 +14,7 @@ class UseStatementHelper
     /** @var string */
     private static $evaldCodeFileNameEnding = "eval()'d code";
 
+    /** @return Import */
     public static function getImports(\ReflectionClass $class): array
     {
         if (!$class->isUserDefined()) {

--- a/src/Middleware/NamespaceResolver.php
+++ b/src/Middleware/NamespaceResolver.php
@@ -69,7 +69,7 @@ class NamespaceResolver extends AbstractMiddleware
         $matches = \array_filter(
             $imports,
             static function (string $import) use ($type) {
-                return $type->getType() === \substr($import, -1 * \strlen($type->getType()));
+                return str_ends_with($import, '\\' . $type->getType()) || $type->getType() === $import;
             }
         );
 

--- a/src/Middleware/NamespaceResolver.php
+++ b/src/Middleware/NamespaceResolver.php
@@ -66,12 +66,13 @@ class NamespaceResolver extends AbstractMiddleware
             return $type;
         }
 
-        $matches = \array_filter(
-            $imports,
-            static function (string $import) use ($type) {
-                return str_ends_with($import, '\\' . $type->getType()) || $type->getType() === $import;
+        $matches = [];
+
+        foreach ($imports as $key => $value) {
+            if (str_ends_with($key, '\\' . $type->getType()) || $type->getType() === $key) {
+                $matches[] = $value;
             }
-        );
+        }
 
         if (count($matches) > 0) {
             return new PropertyType(\array_shift($matches), $type->isArray());

--- a/src/Middleware/NamespaceResolver.php
+++ b/src/Middleware/NamespaceResolver.php
@@ -6,9 +6,9 @@ namespace JsonMapper\Middleware;
 
 use JsonMapper\Cache\NullCache;
 use JsonMapper\Enums\ScalarType;
-use JsonMapper\Helpers\ClassHelper;
 use JsonMapper\Helpers\UseStatementHelper;
 use JsonMapper\JsonMapperInterface;
+use JsonMapper\Parser\Import;
 use JsonMapper\ValueObjects\Property;
 use JsonMapper\ValueObjects\PropertyMap;
 use JsonMapper\ValueObjects\PropertyType;
@@ -60,22 +60,27 @@ class NamespaceResolver extends AbstractMiddleware
         return $intermediatePropertyMap;
     }
 
+    /** @param Import[] $imports */
     private function resolveSingleType(PropertyType $type, ObjectWrapper $object, array $imports): PropertyType
     {
         if (ScalarType::isValid($type->getType())) {
             return $type;
         }
 
-        $matches = [];
+        $matches = \array_filter(
+            $imports,
+            static function (Import $import) use ($type) {
+                $nameSpacedType = "\\{$type->getType()}";
+                if ($import->hasAlias() && $import->getAlias() === $type->getType()) {
+                    return true;
+                }
 
-        foreach ($imports as $key => $value) {
-            if (str_ends_with($key, '\\' . $type->getType()) || $type->getType() === $key) {
-                $matches[] = $value;
+                return $nameSpacedType === \substr($import->getImport(), -strlen($nameSpacedType));
             }
-        }
+        );
 
         if (count($matches) > 0) {
-            return new PropertyType(\array_shift($matches), $type->isArray());
+            return new PropertyType(\array_shift($matches)->getImport(), $type->isArray());
         }
 
         if (class_exists($object->getReflectedObject()->getNamespaceName() . '\\' . $type->getType())) {

--- a/src/Parser/Import.php
+++ b/src/Parser/Import.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonMapper\Parser;
+
+class Import
+{
+    /** @var string */
+    private $import;
+
+    /** @var string|null */
+    private $alias;
+
+    public function __construct(string $import, ?string $alias)
+    {
+        $this->import = $import;
+        $this->alias = $alias;
+    }
+
+    public function getImport(): string
+    {
+        return $this->import;
+    }
+
+    public function getAlias(): ?string
+    {
+        return $this->alias;
+    }
+
+    public function hasAlias(): bool
+    {
+        return ! \is_null($this->alias);
+    }
+}

--- a/src/Parser/UseNodeVisitor.php
+++ b/src/Parser/UseNodeVisitor.php
@@ -10,7 +10,7 @@ use PhpParser\Node\Stmt;
 
 class UseNodeVisitor extends NodeVisitorAbstract
 {
-    /** @var array|string[] */
+    /** @var Import[] */
     private $imports = [];
 
     /**
@@ -20,20 +20,18 @@ class UseNodeVisitor extends NodeVisitorAbstract
     {
         if ($node instanceof Stmt\Use_) {
             foreach ($node->uses as $use) {
-                $this->imports[$use->name->toString()] = $use->name->toString();
-                if ($use->alias) {
-                    $this->imports[$use->alias->name] = $use->name->toString();
-                }
+                $this->imports[] = new Import($use->name->toString(), \is_null($use->alias) ? null : $use->alias->name);
             }
         } elseif ($node instanceof Stmt\GroupUse) {
             foreach ($node->uses as $use) {
-                $this->imports[] = $node->prefix . '\\' . $use->name;
+                $this->imports[] = new Import("{$node->prefix}\\{$use->name}", \is_null($use->alias) ? null : $use->alias->name);
             }
         }
 
         return null;
     }
 
+    /** @return Import[] */
     public function getImports(): array
     {
         return $this->imports;

--- a/src/Parser/UseNodeVisitor.php
+++ b/src/Parser/UseNodeVisitor.php
@@ -20,7 +20,10 @@ class UseNodeVisitor extends NodeVisitorAbstract
     {
         if ($node instanceof Stmt\Use_) {
             foreach ($node->uses as $use) {
-                $this->imports[] = $use->name->toString();
+                $this->imports[$use->name->toString()] = $use->name->toString();
+                if ($use->alias) {
+                    $this->imports[$use->alias->name] = $use->name->toString();
+                }
             }
         } elseif ($node instanceof Stmt\GroupUse) {
             foreach ($node->uses as $use) {

--- a/tests/Implementation/Models/NamespaceAliasObject.php
+++ b/tests/Implementation/Models/NamespaceAliasObject.php
@@ -7,7 +7,7 @@ use JsonMapper\Tests\Implementation\Models\Sub\AnotherValueHolder as Blub;
 class NamespaceAliasObject
 {
     /** @var ValueHolder */
-    public $aVal;
+    public $valueHolder;
     /** @var Blub */
-    public $bVal;
+    public $anotherValueHolder;
 }

--- a/tests/Implementation/Models/NamespaceAliasObject.php
+++ b/tests/Implementation/Models/NamespaceAliasObject.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace JsonMapper\Tests\Implementation\Models;
+
+use JsonMapper\Tests\Implementation\Models\Sub\AnotherValueHolder as Blub;
+
+class NamespaceAliasObject
+{
+    /** @var ValueHolder */
+    public $aVal;
+    /** @var Blub */
+    public $bVal;
+}

--- a/tests/Implementation/Models/NamespaceObject.php
+++ b/tests/Implementation/Models/NamespaceObject.php
@@ -7,7 +7,7 @@ use JsonMapper\Tests\Implementation\Models\Sub\AnotherValueHolder;
 class NamespaceObject
 {
     /** @var ValueHolder */
-    public $aVal;
+    public $valueHolder;
     /** @var AnotherValueHolder */
-    public $bVal;
+    public $anotherValueHolder;
 }

--- a/tests/Implementation/Models/NamespaceObject.php
+++ b/tests/Implementation/Models/NamespaceObject.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace JsonMapper\Tests\Implementation\Models;
+
+use JsonMapper\Tests\Implementation\Models\Sub\AnotherValueHolder;
+
+class NamespaceObject
+{
+    /** @var ValueHolder */
+    public $aVal;
+    /** @var AnotherValueHolder */
+    public $bVal;
+}

--- a/tests/Implementation/Models/Sub/AnotherValueHolder.php
+++ b/tests/Implementation/Models/Sub/AnotherValueHolder.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace JsonMapper\Tests\Implementation\Models\Sub;
+
+class AnotherValueHolder
+{
+    /** @var string */
+    public $value;
+}

--- a/tests/Implementation/Models/ValueHolder.php
+++ b/tests/Implementation/Models/ValueHolder.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace JsonMapper\Tests\Implementation\Models;
+
+class ValueHolder
+{
+    /** @var string */
+    public $value;
+}

--- a/tests/Unit/Helpers/UseStatementHelperTest.php
+++ b/tests/Unit/Helpers/UseStatementHelperTest.php
@@ -17,7 +17,7 @@ class UseStatementHelperTest extends TestCase
     {
         $imports = UseStatementHelper::getImports(new \ReflectionClass($this));
 
-        self::assertEquals([UseStatementHelper::class, SimpleObject::class, TestCase::class], $imports);
+        self::assertEquals([UseStatementHelper::class, SimpleObject::class, TestCase::class], array_values($imports));
     }
 
     /**

--- a/tests/Unit/Helpers/UseStatementHelperTest.php
+++ b/tests/Unit/Helpers/UseStatementHelperTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace JsonMapper\Tests\Unit\Helpers;
 
 use JsonMapper\Helpers\UseStatementHelper;
+use JsonMapper\Parser\Import;
 use JsonMapper\Tests\Implementation\SimpleObject;
 use PHPUnit\Framework\TestCase;
 
@@ -17,7 +18,15 @@ class UseStatementHelperTest extends TestCase
     {
         $imports = UseStatementHelper::getImports(new \ReflectionClass($this));
 
-        self::assertEquals([UseStatementHelper::class, SimpleObject::class, TestCase::class], array_values($imports));
+        self::assertEquals(
+            [
+                new Import(UseStatementHelper::class, null),
+                new Import(Import::class, null),
+                new Import(SimpleObject::class, null),
+                new Import(TestCase::class, null)
+            ],
+            $imports
+        );
     }
 
     /**

--- a/tests/Unit/Middleware/NamespaceResolverTest.php
+++ b/tests/Unit/Middleware/NamespaceResolverTest.php
@@ -195,60 +195,42 @@ class NamespaceResolverTest extends TestCase
     /**
      * @covers \JsonMapper\Middleware\NamespaceResolver
      */
-    public function testUseNonUseMixed(): void
+    public function testReturnsCorrectNamespaceWhenOtherClassHasPartialMatch(): void
     {
         $object = new NamespaceObject();
-
-        $input = [
-            'aVal' => [
-                'value' => 'loremipsum1'
-            ],
-            'bVal' => [
-                'value' => 'loremipsum2'
-            ]
+        $input = (object) [
+            'valueHolder' => (object) ['value' => 'loremipsum1'],
+            'anotherValueHolder' => (object) ['value' => 'loremipsum2']
         ];
+        $mapper = JsonMapperBuilder::new()
+            ->withMiddleware(new DocBlockAnnotations(new NullCache()))
+            ->withMiddleware(new NamespaceResolver(new NullCache()))
+            ->build();
 
-        $builder = JsonMapperBuilder::new();
-        $builder->withMiddleware(new DocBlockAnnotations(new NullCache()));
-        $builder->withMiddleware(new NamespaceResolver(new NullCache()));
+        $mapper->mapObject($input, $object);
 
-        try {
-            $mapper = $builder->build();
-            $mapper->mapObjectFromString(json_encode($input) ?: '', $object);
-        } catch (Exception $e) {
-        }
-
-        self::assertInstanceOf(AnotherValueHolder::class, $object->bVal);
-        self::assertInstanceOf(ValueHolder::class, $object->aVal);
+        self::assertInstanceOf(AnotherValueHolder::class, $object->anotherValueHolder);
+        self::assertInstanceOf(ValueHolder::class, $object->valueHolder);
     }
 
     /**
      * @covers \JsonMapper\Middleware\NamespaceResolver
      */
-    public function testUseAliasMixed(): void
+    public function testReturnsCorrectNamespaceWhenAliasProvidedForUse(): void
     {
         $object = new NamespaceAliasObject();
-
-        $input = [
-            'aVal' => [
-                'value' => 'loremipsum1'
-            ],
-            'bVal' => [
-                'value' => 'loremipsum2'
-            ]
+        $input = (object) [
+            'valueHolder' => (object) ['value' => 'loremipsum1'],
+            'anotherValueHolder' => (object) ['value' => 'loremipsum2']
         ];
+        $mapper = JsonMapperBuilder::new()
+            ->withMiddleware(new DocBlockAnnotations(new NullCache()))
+            ->withMiddleware(new NamespaceResolver(new NullCache()))
+            ->build();
 
-        $builder = JsonMapperBuilder::new();
-        $builder->withMiddleware(new DocBlockAnnotations(new NullCache()));
-        $builder->withMiddleware(new NamespaceResolver(new NullCache()));
+        $mapper->mapObject($input, $object);
 
-        try {
-            $mapper = $builder->build();
-            $mapper->mapObjectFromString(json_encode($input) ?: '', $object);
-        } catch (Exception $e) {
-        }
-
-        self::assertInstanceOf(AnotherValueHolder::class, $object->bVal);
-        self::assertInstanceOf(ValueHolder::class, $object->aVal);
+        self::assertInstanceOf(AnotherValueHolder::class, $object->anotherValueHolder);
+        self::assertInstanceOf(ValueHolder::class, $object->valueHolder);
     }
 }

--- a/tests/Unit/Middleware/NamespaceResolverTest.php
+++ b/tests/Unit/Middleware/NamespaceResolverTest.php
@@ -14,6 +14,7 @@ use JsonMapper\Middleware\DocBlockAnnotations;
 use JsonMapper\Middleware\NamespaceResolver;
 use JsonMapper\Tests\Helpers\AssertThatPropertyTrait;
 use JsonMapper\Tests\Implementation\ComplexObject;
+use JsonMapper\Tests\Implementation\Models\NamespaceAliasObject;
 use JsonMapper\Tests\Implementation\Models\NamespaceObject;
 use JsonMapper\Tests\Implementation\Models\Sub\AnotherValueHolder;
 use JsonMapper\Tests\Implementation\Models\User;
@@ -197,6 +198,36 @@ class NamespaceResolverTest extends TestCase
     public function testUseNonUseMixed(): void
     {
         $object = new NamespaceObject();
+
+        $input = [
+            'aVal' => [
+                'value' => 'loremipsum1'
+            ],
+            'bVal' => [
+                'value' => 'loremipsum2'
+            ]
+        ];
+
+        $builder = JsonMapperBuilder::new();
+        $builder->withMiddleware(new DocBlockAnnotations(new NullCache()));
+        $builder->withMiddleware(new NamespaceResolver(new NullCache()));
+
+        try {
+            $mapper = $builder->build();
+            $mapper->mapObjectFromString(json_encode($input) ?: '', $object);
+        } catch (Exception $e) {
+        }
+
+        self::assertInstanceOf(AnotherValueHolder::class, $object->bVal);
+        self::assertInstanceOf(ValueHolder::class, $object->aVal);
+    }
+
+    /**
+     * @covers \JsonMapper\Middleware\NamespaceResolver
+     */
+    public function testUseAliasMixed(): void
+    {
+        $object = new NamespaceAliasObject();
 
         $input = [
             'aVal' => [

--- a/tests/Unit/Parser/ImportTest.php
+++ b/tests/Unit/Parser/ImportTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonMapper\Tests\Unit\Parser;
+
+use JsonMapper\Parser\Import;
+use PHPUnit\Framework\TestCase;
+
+class ImportTest extends TestCase
+{
+    /**
+     * @covers \JsonMapper\Parser\Import
+     */
+    public function testCanHoldProperties(): void
+    {
+        $import = new Import(\stdClass::class, null);
+
+        self::assertEquals(\stdClass::class, $import->getImport());
+        self::assertNull($import->getAlias());
+        self::assertFalse($import->hasAlias());
+    }
+
+    /**
+     * @covers \JsonMapper\Parser\Import
+     */
+    public function testCanHoldPropertiesWithAlias(): void
+    {
+        $import = new Import(\stdClass::class, 'someAlias');
+
+        self::assertEquals(\stdClass::class, $import->getImport());
+        self::assertEquals('someAlias', $import->getAlias());
+        self::assertTrue($import->hasAlias());
+    }
+}

--- a/tests/Unit/Parser/UseNodeVisitorTest.php
+++ b/tests/Unit/Parser/UseNodeVisitorTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JsonMapper\Tests\Unit\Parser;
 
+use JsonMapper\Parser\Import;
 use JsonMapper\Parser\UseNodeVisitor;
 use JsonMapper\Tests\Implementation\ComplexObject;
 use JsonMapper\Tests\Implementation\SimpleObject;
@@ -21,16 +22,19 @@ class UseNodeVisitorTest extends TestCase
     public function testKeepsSingleImportsFromNodeForRetrieval(): void
     {
         $visitor = new UseNodeVisitor();
-        $uses = [\DateTime::class, \stdClass::class];
-        $node = new Use_(array_map(static function ($use) {
-            return new UseUse(new Name($use));
+        $uses = [
+            new Import(\DateTime::class, null),
+            new Import(\stdClass::class, null)
+        ];
+        $node = new Use_(array_map(static function (Import $use) {
+            return new UseUse(new Name($use->getImport()));
         }, $uses));
 
         $result = $visitor->enterNode($node);
         $imports = $visitor->getImports();
 
         self::assertNull($result);
-        self::assertEquals($uses, array_values($imports));
+        self::assertEquals($uses, $imports);
     }
 
     /**
@@ -48,6 +52,6 @@ class UseNodeVisitorTest extends TestCase
         $imports = $visitor->getImports();
 
         self::assertNull($result);
-        self::assertEquals([ComplexObject::class, SimpleObject::class], $imports);
+        self::assertEquals([New Import(ComplexObject::class, null), new Import(SimpleObject::class, null)], $imports);
     }
 }

--- a/tests/Unit/Parser/UseNodeVisitorTest.php
+++ b/tests/Unit/Parser/UseNodeVisitorTest.php
@@ -30,7 +30,7 @@ class UseNodeVisitorTest extends TestCase
         $imports = $visitor->getImports();
 
         self::assertNull($result);
-        self::assertEquals($uses, $imports);
+        self::assertEquals($uses, array_values($imports));
     }
 
     /**


### PR DESCRIPTION
Fixes problems with mixing classes in the current namespaces and another.

I observed problems with mixing classes in the current namespace and another namespace. Especially problematic is that in the current implementation it only checks if the classname ends with the class declared in the docblock.

To show this behavior a bit clearer, I tried my best to implement a test for that problem.

You will see that without my changes. $bVal is "ValueHolder" instead of "AnotherValueHolder"


While I was already in there, I implemented support for the alias syntax for 'use' statements.