### PR TITLE
fix: Support private properties from parent class in DocBlockAnnotations and TypedProperties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed 
+- Support private properties from parent class in DocBlockAnnotations and TypedProperties [PR#161](https://github.com/JsonMapper/JsonMapper/pull/161)
 
 ## [2.17.0] - 2023-05-02
 ### Changed

--- a/src/Middleware/DocBlockAnnotations.php
+++ b/src/Middleware/DocBlockAnnotations.php
@@ -45,10 +45,8 @@ class DocBlockAnnotations extends AbstractMiddleware
             return $this->cache->get($cacheKey);
         }
 
-        $properties = $object->getReflectedObject()->getProperties();
         $intermediatePropertyMap = new PropertyMap();
-
-        foreach ($properties as $property) {
+        foreach ($this->getObjectPropertiesIncludingParents($object) as $property) {
             $name = $property->getName();
             $docBlock = $property->getDocComment();
             if ($docBlock === false) {
@@ -128,5 +126,16 @@ class DocBlockAnnotations extends AbstractMiddleware
         }
 
         return new AnnotationMap($var ?: null, [], null);
+    }
+
+    /** @return \ReflectionProperty[] */
+    public function getObjectPropertiesIncludingParents(ObjectWrapper $object): array
+    {
+        $properties = [];
+        $reflectionClass = $object->getReflectedObject();
+        do {
+            $properties = array_merge($properties, $reflectionClass->getProperties());
+        } while ($reflectionClass = $reflectionClass->getParentClass());
+        return $properties;
     }
 }

--- a/src/Middleware/TypedProperties.php
+++ b/src/Middleware/TypedProperties.php
@@ -44,10 +44,9 @@ class TypedProperties extends AbstractMiddleware
             return $this->cache->get($cacheKey);
         }
 
-        $reflectionProperties = $object->getReflectedObject()->getProperties();
         $intermediatePropertyMap = new PropertyMap();
 
-        foreach ($reflectionProperties as $reflectionProperty) {
+        foreach ($this->getObjectPropertiesIncludingParents($object) as $reflectionProperty) {
             $type = $reflectionProperty->getType();
 
             if ($type instanceof ReflectionNamedType) {
@@ -96,5 +95,16 @@ class TypedProperties extends AbstractMiddleware
         $this->cache->set($cacheKey, $intermediatePropertyMap);
 
         return $intermediatePropertyMap;
+    }
+
+    /** @return \ReflectionProperty[] */
+    public function getObjectPropertiesIncludingParents(ObjectWrapper $object): array
+    {
+        $properties = [];
+        $reflectionClass = $object->getReflectedObject();
+        do {
+            $properties = array_merge($properties, $reflectionClass->getProperties());
+        } while ($reflectionClass = $reflectionClass->getParentClass());
+        return $properties;
     }
 }

--- a/tests/Implementation/Php74/SimpleObject.php
+++ b/tests/Implementation/Php74/SimpleObject.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonMapper\Tests\Implementation\Php74;
+
+class SimpleObject
+{
+    private string $name;
+
+    public function __construct(string $name = '')
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+}

--- a/tests/Implementation/Php74/SimpleObjectExtension.php
+++ b/tests/Implementation/Php74/SimpleObjectExtension.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonMapper\Tests\Implementation\Php74;
+
+class SimpleObjectExtension extends SimpleObject
+{
+}

--- a/tests/Implementation/SimpleObjectExtension.php
+++ b/tests/Implementation/SimpleObjectExtension.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonMapper\Tests\Implementation;
+
+class SimpleObjectExtension extends SimpleObject
+{
+}

--- a/tests/Integration/FeatureSupportsMappingToParentPrivateProperties.php
+++ b/tests/Integration/FeatureSupportsMappingToParentPrivateProperties.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonMapper\Tests\Integration;
+
+use JsonMapper\JsonMapperBuilder;
+use JsonMapper\Tests\Implementation\SimpleObjectExtension;
+use JsonMapper\Tests\Implementation\Php74\SimpleObjectExtension as TypedSimpleObjectExtension;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+class FeatureSupportsMappingToParentPrivateProperties extends TestCase
+{
+    public function testItCanMapAnObjectUsingPrivatePropertiesInTheParentClassUsingDocBlocks(): void
+    {
+        // Arrange
+        $mapper = JsonMapperBuilder::new()
+            ->withDocBlockAnnotationsMiddleware()
+            ->build();
+        $json = (object) ['name' => __METHOD__];
+
+        // Act
+        $object = $mapper->mapToClass($json, SimpleObjectExtension::class);
+
+        // Assert
+        self::assertSame(__METHOD__, $object->getName());
+    }
+
+    public function testItCanMapAnObjectUsingPrivatePropertiesInTheParentClassUsingTypedProperties(): void
+    {
+        // Arrange
+        $mapper = JsonMapperBuilder::new()
+            ->withTypedPropertiesMiddleware()
+            ->build();
+        $json = (object) ['name' => __METHOD__];
+
+        // Act
+        $object = $mapper->mapToClass($json, TypedSimpleObjectExtension::class);
+
+        // Assert
+        self::assertSame(__METHOD__, $object->getName());
+    }
+}


### PR DESCRIPTION
Fixes #158 