### PR TITLE
fix: Corrected master for main in workflows and docs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,9 @@ name: Build
 
 on:
   push:
-    branches: [ develop, master ]
+    branches: [ develop, main ]
   pull_request:
-    branches: [ develop, master ]
+    branches: [ develop, main ]
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Corrected master for main in workflows and docs [PR#174](https://github.com/JsonMapper/JsonMapper/pull/174)
 
 ## [2.20.0] - 2023-10-09
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ For more information see the project website: https://jsonmapper.net/
 [![GitHub](https://img.shields.io/github/license/JsonMapper/JsonMapper)](https://choosealicense.com/licenses/mit/)
 [![Packagist Version](https://img.shields.io/packagist/v/json-mapper/json-mapper)](https://packagist.org/packages/json-mapper/json-mapper) 
 [![PHP from Packagist](https://img.shields.io/packagist/php-v/json-mapper/json-mapper)](#)
-![Build](https://github.com/JsonMapper/JsonMapper/workflows/Build/badge.svg?branch=master)
+![Build](https://github.com/JsonMapper/JsonMapper/workflows/Build/badge.svg?branch=main)
 [![Coverage Status](https://coveralls.io/repos/github/JsonMapper/JsonMapper/badge.svg?branch=develop)](https://coveralls.io/github/JsonMapper/JsonMapper?branch=develop)
 
 # Why use JsonMapper
@@ -90,7 +90,7 @@ $mapper->push(new class extends JsonMapper\Middleware\AbstractMiddleware {
 ```
 
 # Contributing
-Please refer to [CONTRIBUTING.md](https://github.com/JsonMapper/JsonMapper/blob/master/CONTRIBUTING.md) for information on how to contribute to JsonMapper.
+Please refer to [CONTRIBUTING.md](https://github.com/JsonMapper/JsonMapper/blob/main/CONTRIBUTING.md) for information on how to contribute to JsonMapper.
 
 ## List of Contributors
 Thanks to everyone who has contributed to JsonMapper! You can find a detailed list of contributors of JsonMapper on [GitHub](https://github.com/JsonMapper/JsonMapper/graphs/contributors).
@@ -101,4 +101,4 @@ Thanks to everyone who has contributed to JsonMapper! You can find a detailed li
 This project is sponsored by JetBrains providing an open source license to continue building on JsonMapper without cost.     
 
 # License
-The MIT License (MIT). Please see [License File](https://github.com/JsonMapper/JsonMapper/blob/master/LICENSE) for more information.
+The MIT License (MIT). Please see [License File](https://github.com/JsonMapper/JsonMapper/blob/main/LICENSE) for more information.


### PR DESCRIPTION
| Q             | A                                                                                                                         |
| ------------- |---------------------------------------------------------------------------------------------------------------------------|
| Branch?       | develop                                                     |
| Bug fix?      | yes                                                                                                                   |
| New feature?  | no                                                                                                                    |
| Deprecations? | no                                                                                                                    |
| Tickets       | 
| License       | MIT                                                                                                                       |
| Changelog     | Yes |
| Doc PR        | N/A|

Replace references to the old `master` branch and replace them with the new `main`
