### PR TITLE
Fix final callback no called after previous exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - Corrected master for main in workflows and docs [PR#174](https://github.com/JsonMapper/JsonMapper/pull/174)
+- Fix FinalCallback not called after a previous exception [PR#173](https://github.com/JsonMapper/JsonMapper/pull/173). Thanks to [hyde1](https://github.com/hyde1) for creating the PR.
+
 
 ## [2.20.0] - 2023-10-09
 ### Fixed

--- a/src/Middleware/FinalCallback.php
+++ b/src/Middleware/FinalCallback.php
@@ -35,8 +35,11 @@ class FinalCallback implements MiddlewareInterface
             $handler
         ) {
             self::$nestingLevel++;
-            $handler($json, $object, $map, $mapper);
-            self::$nestingLevel--;
+			try {
+				$handler($json, $object, $map, $mapper);
+			} finally {
+				self::$nestingLevel--;
+			}
 
             if (! $this->onlyApplyCallBackOnTopLevel || self::$nestingLevel === 0) {
                 \call_user_func($this->callback, $json, $object, $map, $mapper);

--- a/src/Middleware/FinalCallback.php
+++ b/src/Middleware/FinalCallback.php
@@ -35,11 +35,11 @@ class FinalCallback implements MiddlewareInterface
             $handler
         ) {
             self::$nestingLevel++;
-			try {
-				$handler($json, $object, $map, $mapper);
-			} finally {
-				self::$nestingLevel--;
-			}
+            try {
+                $handler($json, $object, $map, $mapper);
+            } finally {
+                self::$nestingLevel--;
+            }
 
             if (! $this->onlyApplyCallBackOnTopLevel || self::$nestingLevel === 0) {
                 \call_user_func($this->callback, $json, $object, $map, $mapper);

--- a/tests/Integration/Middleware/FinalCallbackTest.php
+++ b/tests/Integration/Middleware/FinalCallbackTest.php
@@ -33,6 +33,33 @@ class FinalCallbackTest extends TestCase
     /**
      * @covers \JsonMapper\Middleware\FinalCallback
      */
+    public function testCallbackIsInvokedEvenAfterException(): void
+    {
+        $invocationCount = 0;
+        $callback = static function () use (&$invocationCount) {
+            $invocationCount++;
+        };
+        $mapper = (new JsonMapperFactory())->default();
+        $mapper->push(new FinalCallback($callback));
+        $object = new ComplexObject();
+        $invalidJson = (object) ['user' => (object) ['name' => new \DateTime()]];
+
+        try {
+            $mapper->mapObject($invalidJson, $object);
+            self::fail('Should throw exception!');
+        } catch (\Throwable $e) {
+            self::assertEquals('Object of class DateTime could not be converted to string', $e->getMessage());
+        }
+
+        $json = (object) ['user' => (object) ['name' => __METHOD__]];
+        $mapper->mapObject($json, $object);
+
+        self::assertEquals(1, $invocationCount);
+    }
+
+    /**
+     * @covers \JsonMapper\Middleware\FinalCallback
+     */
     public function testCallbackIsInvokedForEveryPass(): void
     {
         $invocationCount = 0;


### PR DESCRIPTION
| Q             | A                                                                                                                         |
| ------------- |---------------------------------------------------------------------------------------------------------------------------|
| Branch?       | develop                                                     |
| Bug fix?      | yes                                                                                                                   |
| New feature?  | no                                                                                                                    |
| Deprecations? | no                                                                                                                    |
| Tickets       | N/A |
| License       | MIT                                                                                                                       |
| Changelog     | Yes |
| Doc PR        | N/A/  |

Bug: The FinalCallback middleware looses count of self::$nestingLevel if a exception is raised during json mapping. After an exception the callback is never call on the following sucessful mapping calls.
Fix: just include the self::$nestingLevel--; in a finally block so it is called even if an exception is raised.

An integration test has been added to make sure the issue is fixed.
