### PR TITLE
Feat: Add with mapping of associative array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "psr/simple-cache": " ^1.0 || ^2.0 || ^3.0",
         "symfony/cache": "^4.4 || ^5.0 || ^6.0",
-        "symfony/polyfill-php73": "^1.18"
+        "symfony/polyfill-php73": "^1.18",
+        "symfony/polyfill-php81": "^1.29"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^6.5 || ^7.0",

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -89,12 +89,19 @@ class JsonMapper implements JsonMapperInterface
         return $this;
     }
 
-    public function mapToClass(\stdClass $json, string $class)
+    public function mapToClass($json, string $class)
     {
+        if (!$json instanceof \stdClass && (\is_array($json) && array_is_list($json))) {
+            throw TypeError::forArgument(__METHOD__, '\stdClass|array<string, mixed>', $json, 1, '$json');
+        }
+
         if (! \class_exists($class)) {
             throw TypeError::forArgument(__METHOD__, 'class-string', $class, 2, '$class');
         }
 
+        if (is_array($json)) {
+            $json = (object) $json;
+        }
         $propertyMap = new PropertyMap();
 
         $handler = $this->resolve();

--- a/src/JsonMapperInterface.php
+++ b/src/JsonMapperInterface.php
@@ -29,10 +29,11 @@ interface JsonMapperInterface
 
     /**
      * @template T of object
+     * @param \stdClass|array<string, mixed> $json
      * @psalm-param class-string<T> $class
      * @return T
      */
-    public function mapToClass(\stdClass $json, string $class);
+    public function mapToClass($json, string $class);
 
     /**
      * @template T of object

--- a/tests/Implementation/JsonMapper.php
+++ b/tests/Implementation/JsonMapper.php
@@ -85,8 +85,11 @@ class JsonMapper implements JsonMapperInterface
         return $this;
     }
 
-    public function mapToClass(\stdClass $json, string $class)
+    public function mapToClass($json, string $class)
     {
+        if (!$json instanceof \stdClass && (\is_array($json) && array_is_list($json))) {
+            throw TypeError::forArgument(__METHOD__, '\stdClass|array<string, mixed>', $json, 1, '$json');
+        }
         if (! \class_exists($class)) {
             throw new \Exception(); // @todo proper exception message
         }

--- a/tests/Integration/FeatureSupportsMapToClassWithAssociativeArray.php
+++ b/tests/Integration/FeatureSupportsMapToClassWithAssociativeArray.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonMapper\Tests\Integration;
+
+use JsonMapper\JsonMapperFactory;
+use JsonMapper\Tests\Implementation\Popo;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversNothing
+ */
+class FeatureSupportsMapToClassWithAssociativeArray extends TestCase
+{
+    public function testItCanMapToClass(): void
+    {
+        // Arrange
+        $mapper = (new JsonMapperFactory())->bestFit();
+        $json =  json_decode('{"name": "one"}', true);
+
+        // Act
+        $object = $mapper->mapToClass($json, Popo::class);
+
+        // Assert
+        self::assertSame('one', $object->name);
+    }
+}


### PR DESCRIPTION
| Q             | A                                                                                  |
|---------------|------------------------------------------------------------------------------------|
| Branch?       | develop                      |
| Bug fix?      | nu |
| New feature?  | yes |
| Deprecations? | no |
| Tickets       | Fix #176 |
| License       | MIT                                                                                |
| Changelog     | _Pending_ |
| Doc PR        | _Pending_ |

This PR is a first step into seeing if mapping of associative arrays can be added without breaking backwards compatibility but only by supporting more argument types. Whilst keeping the changes to a minimum.