### PR TITLE
Add support for symfony/cache 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add compatibility with symfony/cache:^7.0 [PR#184](https://github.com/JsonMapper/JsonMapper/pull/184)
 
 ## [2.22.0] - 2024-03-05
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "nikic/php-parser": "^4.13",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "psr/simple-cache": " ^1.0 || ^2.0 || ^3.0",
-        "symfony/cache": "^4.4 || ^5.0 || ^6.0",
+        "symfony/cache": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "symfony/polyfill-php73": "^1.18"
     },
     "require-dev": {


### PR DESCRIPTION
| Q             | A                                                                                  |
|---------------|------------------------------------------------------------------------------------|
| Branch?       | develop                       |
| Bug fix?      | no                                                                             |
| New feature?  | yes                                                                             |
| Deprecations? | no                                                                             |
| Tickets       | none |
| License       | MIT                                                                                |
| Changelog     | none |
| Doc PR        | none   |

When requiring json-mapper/json-mapper in a Symfony 7 project, it installs 2.15.0 because newer versions depend on symfony/cache which conflicts with symfony/cache:^7

According to the [changelog](https://github.com/symfony/symfony/blob/7.1/src/Symfony/Component/Cache/CHANGELOG.md), only DB cache might be affected by the version increase, which is not used in JsonMapper.