### PR TITLE
Added support for nikic/php-parser:^5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Added support for nikic/php-parser:^5.0 [PR#185](https://github.com/JsonMapper/JsonMapper/pull/185)
 ### Fixed
 - Resolve Nodejs16 deprecations warnings [PR#186](https://github.com/JsonMapper/JsonMapper/pull/186)
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^7.1 || ^8.0",
         "ext-json": "*",
         "myclabs/php-enum": "^1.7",
-        "nikic/php-parser": "^4.13",
+        "nikic/php-parser": "^4.13 || ^5.0",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "psr/simple-cache": " ^1.0 || ^2.0 || ^3.0",
         "symfony/cache": "^4.4 || ^5.0 || ^6.0 || ^7.0",

--- a/src/Helpers/UseStatementHelper.php
+++ b/src/Helpers/UseStatementHelper.php
@@ -49,7 +49,9 @@ class UseStatementHelper
             throw new \RuntimeException("Unable to read {$filename}");
         }
 
-        $parser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+        $parser = method_exists(ParserFactory::class, 'createForNewestSupportedVersion')
+          ? (new ParserFactory())->createForNewestSupportedVersion()
+          : (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
 
         try {
             $ast = $parser->parse($contents);


### PR DESCRIPTION
| Q             | A                                                                                  |
|---------------|------------------------------------------------------------------------------------|
| Branch?       | develop                       |
| Bug fix?      | no                                                                             |
| New feature?  | yes                                                                            |
| Deprecations? | no                                                                             |
| Tickets       | none |
| License       | MIT                                                                                |
| Changelog     | changed |
| Doc PR        | none |

Upgrade of dependency nikic/php-parser

Only notable change I could find is the removed ParserFactory::create method, for which I used the recommended alternative with a fallback for older versions

https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-5.0.md#changes-to-the-parser-factory