### PR TITLE
Resolve nodejs16 deprecations messages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Validate composer.json and composer.lock
       run: composer validate

--- a/.github/workflows/phpcs.yaml
+++ b/.github/workflows/phpcs.yaml
@@ -11,7 +11,7 @@ jobs:
   phpcs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # important!
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Resolve Nodejs16 deprecations warnings [PR#186](https://github.com/JsonMapper/JsonMapper/pull/186)
 
 ## [2.22.1] - 2024-05-04
 ### Changed


### PR DESCRIPTION
| Q             | A                                                                                  |
|---------------|------------------------------------------------------------------------------------|
| Branch?       | develop |
| Bug fix?      | yes |
| New feature?  | no | 
| Deprecations? | no |
| Tickets       | N/A |
| License       | MIT                                                                                |
| Changelog     | Yes |
| Doc PR        | N/A |

On https://github.com/JsonMapper/JsonMapper/actions/runs/8928772434 you can see the warnings
> [PHP PHP 8.3 with latest deps](https://github.com/JsonMapper/JsonMapper/actions/runs/8928772434/job/24525045874)
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.