### PR TITLE
ci: add php 8.4 to build matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,6 +76,15 @@ jobs:
             composer_update_flags: '--prefer-lowest --prefer-stable'
             php_ini: 'xdebug.coverage_enable=On'
             name: 'PHP 8.3 with lowest stable deps'
+          - php: 8.4
+            allow_fail: false
+            php_ini: 'xdebug.coverage_enable=On'
+            name: 'PHP 8.4 with latest deps'
+          - php: 8.4
+            allow_fail: false
+            composer_update_flags: '--prefer-lowest --prefer-stable'
+            php_ini: 'xdebug.coverage_enable=On'
+            name: 'PHP 8.4 with lowest stable deps'
 
     runs-on: ubuntu-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Include PHP 8.4 in build matrix [PR#187](https://github.com/JsonMapper/JsonMapper/pull/187)
 
 ## [2.22.3] - 2025-02-03
 ### Fixed


### PR DESCRIPTION
| Q             | A                  |
|---------------|-------|
| Branch?       | develop  |
| Bug fix?      | no            |
| New feature?  | no       |
| Deprecations? | no      |
| Tickets       | N/A           |
| License       | MIT          |
| Changelog     | Each PR should contain a changelog entry, see https://keepachangelog.com/en/1.0.0/ |
| Doc PR        | JsonMapper/jsonmapper.github.io#... <!-- could be required for new features -->    |

This pull request includes updates to the build configuration for PHP versions in the GitHub Actions workflow. The most important changes are as follows:

Updates to PHP versions in the build configuration:

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R79-R87): Added configurations for PHP 8.4 with both the latest and the lowest stable dependencies.
