### PR TITLE
Fix implicit null deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix implicit null deprecations
 
 ## [2.22.2] - 2024-05-14
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Fix implicit null deprecations
+- Fix implicit null deprecations [PR#189](https://github.com/JsonMapper/JsonMapper/pull/189)
 
 ## [2.22.2] - 2024-05-14
 ### Changed

--- a/src/Handler/PropertyMapper.php
+++ b/src/Handler/PropertyMapper.php
@@ -24,9 +24,9 @@ class PropertyMapper
     private $valueFactory;
 
     public function __construct(
-        FactoryRegistry $classFactoryRegistry = null,
-        FactoryRegistry $nonInstantiableTypeResolver = null,
-        IScalarCaster $casterHelper = null
+        ?FactoryRegistry $classFactoryRegistry = null,
+        ?FactoryRegistry $nonInstantiableTypeResolver = null,
+        ?IScalarCaster $casterHelper = null
     ) {
         if ($classFactoryRegistry === null) {
             $classFactoryRegistry = FactoryRegistry::withNativePhpClassesAdded();

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -18,7 +18,7 @@ class JsonMapper implements JsonMapperInterface
     /** @var callable|null */
     private $cached;
 
-    public function __construct(callable $propertyMapper = null)
+    public function __construct(?callable $propertyMapper = null)
     {
         $this->propertyMapper = $propertyMapper;
     }

--- a/src/JsonMapperFactory.php
+++ b/src/JsonMapperFactory.php
@@ -12,12 +12,12 @@ class JsonMapperFactory
     /** @var JsonMapperBuilder */
     private $builder;
 
-    public function __construct(JsonMapperBuilder $builder = null)
+    public function __construct(?JsonMapperBuilder $builder = null)
     {
         $this->builder = $builder ?? JsonMapperBuilder::new();
     }
 
-    public function create(PropertyMapper $propertyMapper = null, MiddlewareInterface ...$handlers): JsonMapperInterface
+    public function create(?PropertyMapper $propertyMapper = null, MiddlewareInterface ...$handlers): JsonMapperInterface
     {
         $builder = clone ($this->builder);
         $builder->withPropertyMapper($propertyMapper ?? new PropertyMapper());

--- a/src/Middleware/Constructor/DefaultFactory.php
+++ b/src/Middleware/Constructor/DefaultFactory.php
@@ -41,7 +41,7 @@ class DefaultFactory
         JsonMapperInterface $mapper,
         IScalarCaster $scalarCaster,
         FactoryRegistry $classFactoryRegistry,
-        FactoryRegistry $nonInstantiableTypeResolver = null
+        ?FactoryRegistry $nonInstantiableTypeResolver = null
     ) {
         $reflectedClass = $reflectedConstructor->getDeclaringClass();
         $this->objectName = $objectName;

--- a/src/Middleware/NamespaceResolver.php
+++ b/src/Middleware/NamespaceResolver.php
@@ -20,7 +20,7 @@ class NamespaceResolver extends AbstractMiddleware
     /** @var CacheInterface */
     private $cache;
 
-    public function __construct(CacheInterface $cache = null)
+    public function __construct(?CacheInterface $cache = null)
     {
         $this->cache = $cache ?? new NullCache();
     }

--- a/tests/Implementation/Models/Square.php
+++ b/tests/Implementation/Models/Square.php
@@ -11,7 +11,7 @@ class Square extends AbstractShape
     /** @var int */
     public $length;
 
-    public function __construct(int $width = null, int $length = null)
+    public function __construct(?int $width = null, ?int $length = null)
     {
         $this->width = $width;
         $this->length = $length;


### PR DESCRIPTION
| Q             | A                                                                                  |
|---------------|------------------------------------------------------------------------------------|
| Branch?       | main |
| Bug fix?      | yes |
| New feature?  | no                                                                             |
| Deprecations? | yes                                                                            |
| Tickets       |  |
| License       | MIT                                                                                |
| Changelog     | Fix implicit null deprecations |
| Doc PR        | N/A   |

This PR fixes the PHP 8.4 deprecations of the following type:

```
[info] Deprecated: JsonMapper\JsonMapperFactory::__construct(): Implicitly marking parameter $builder as nullable is deprecated, the explicit nullable type must be used instead
[info] Deprecated: JsonMapper\JsonMapperFactory::create(): Implicitly marking parameter $propertyMapper as nullable is deprecated, the explicit nullable type must be used instead
[info] Deprecated: JsonMapper\Handler\PropertyMapper::__construct(): Implicitly marking parameter $classFactoryRegistry as nullable is deprecated, the explicit nullable type must be used instead
[info] Deprecated: JsonMapper\Handler\PropertyMapper::__construct(): Implicitly marking parameter $nonInstantiableTypeResolver as nullable is deprecated, the explicit nullable type must be used instead
[info] Deprecated: JsonMapper\Handler\PropertyMapper::__construct(): Implicitly marking parameter $casterHelper as nullable is deprecated, the explicit nullable type must be used instead
[info] Deprecated: JsonMapper\Middleware\NamespaceResolver::__construct(): Implicitly marking parameter $cache as nullable is deprecated, the explicit nullable type must be used instead
[info] Deprecated: JsonMapper\JsonMapper::__construct(): Implicitly marking parameter $propertyMapper as nullable is deprecated, the explicit nullable type must be used instead
```