### PR TITLE
feat: support list<t> and array<TKey, TValue> in constructor middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add support list and array<TKey, TValue> in constructor middleware [PR#194](https://github.com/JsonMapper/JsonMapper/pull/194)
 
 ## [2.23.0] - 2025-04-08
 ### Added

--- a/src/Helpers/DocBlockHelper.php
+++ b/src/Helpers/DocBlockHelper.php
@@ -8,7 +8,7 @@ use JsonMapper\ValueObjects\AnnotationMap;
 
 class DocBlockHelper
 {
-    private const PATTERN = '/@(?P<annotation>[A-Za-z_-]+)[ \t]+(?P<type>\??[\w\[\]\\\\|]*)[ \t]?\$?(?P<name>[\w\[\]\\\\|]*)/m';
+    private const PATTERN = '/@(?P<annotation>[A-Za-z_-]+)[ \t]+(?P<type>\??(?:[\w\[\]\\\\|<>]+(?:,\s*)?)*)[ \t]*\$?(?P<name>[\w\[\]\\\\|]*)/m';
 
     public static function parseDocBlockToAnnotationMap(string $docBlock): AnnotationMap
     {

--- a/tests/Implementation/PopoArrayLtGt.php
+++ b/tests/Implementation/PopoArrayLtGt.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonMapper\Tests\Implementation;
+
+class PopoArrayLtGt
+{
+    /** @var array<int, Popo> */
+    private $items;
+
+    /** @param array<int, Popo> $items */
+    public function __construct(array $items)
+    {
+        $this->items = $items;
+    }
+
+    /** @return array<int, Popo> */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+}

--- a/tests/Implementation/PopoList.php
+++ b/tests/Implementation/PopoList.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace JsonMapper\Tests\Implementation;
+
+class PopoList
+{
+    /** @var list<Popo> */
+    private $items;
+
+    /** @param list<Popo> $items */
+    public function __construct(array $items)
+    {
+        $this->items = $items;
+    }
+
+    /** @return list<Popo> */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+}


### PR DESCRIPTION
| Q             | A                                                                                  |
|---------------|------------------------------------------------------------------------------------|
| Branch?       | develop|
| Bug fix?      | no                                                                             |
| New feature?  | yes                                                                             |
| Deprecations? | no                                                                             |
| Tickets       |  |
| License       | MIT                                                                                |
| Changelog     | Add support list<t> and array<TKey, TValue> in constructor middleware |
| Doc PR        | JsonMapper/jsonmapper.github.io#43|

Following #193 this adds support for `list<T>` and `array<TKey, TValue>` in the constructor middleware.
