### PR TITLE
refactor: raise minimum php level

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,27 +12,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - php: 7.1
-            allow_fail: false
-            name: 'PHP 7.1 with latest deps'
-          - php: 7.1
-            allow_fail: false
-            composer_update_flags: '--prefer-lowest --prefer-stable'
-            name: 'PHP 7.1 with lowest stable deps'
-          - php: 7.2
-            allow_fail: false
-            name: 'PHP 7.2 with latest deps'
-          - php: 7.2
-            allow_fail: false
-            composer_update_flags: '--prefer-lowest --prefer-stable'
-            name: 'PHP 7.2 with lowest stable deps'
-          - php: 7.3
-            allow_fail: false
-            name: 'PHP 7.3 with latest deps'
-          - php: 7.3
-            allow_fail: false
-            composer_update_flags: '--prefer-lowest --prefer-stable'
-            name: 'PHP 7.3 with lowest stable deps'
           - php: 7.4
             allow_fail: false
             name: 'PHP 7.4 with latest deps'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+- Support for PHP 7.1, 7.2 and 7.3 has been removed. [PR#197](https://github.com/JsonMapper/JsonMapper/pull/197)
 
 ## [2.24.0] - 2025-04-08
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "license": "MIT",
     "minimum-stability": "stable",
     "require": {
-        "php": "^7.1 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "ext-json": "*",
         "myclabs/php-enum": "^1.7",
         "nikic/php-parser": "^4.13 || ^5.0",

--- a/src/Helpers/DocBlockHelper.php
+++ b/src/Helpers/DocBlockHelper.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace JsonMapper\Helpers;
 
+use JsonMapper\Parser\Import;
 use JsonMapper\ValueObjects\AnnotationMap;
+use JsonMapper\ValueObjects\ArrayInformation;
+use JsonMapper\ValueObjects\PropertyType;
 
 class DocBlockHelper
 {
@@ -35,5 +38,89 @@ class DocBlockHelper
         }
 
         return new AnnotationMap($var ?: null, $params, null);
+    }
+
+    /**
+     * @param Import[] $imports
+     * @return PropertyType[]
+     */
+    public static function deriveTypesFromDocBlockType(string $docBlockType, \ReflectionClass $class, array $imports): array
+    {
+        $types = [];
+
+        if (strpos($docBlockType, '?') === 0) {
+            $docBlockType = \substr($docBlockType, 1);
+        }
+
+        $docBlockTypes = \explode('|', $docBlockType);
+        $docBlockTypes = \array_filter($docBlockTypes, static function (string $docBlockType) {
+            return $docBlockType !== 'null';
+        });
+
+        foreach ($docBlockTypes as $dt) {
+            $dt = \trim($dt);
+            $isAnArrayType = self::isArrayType($dt);
+
+            if (! $isAnArrayType) {
+                $type = NamespaceHelper::resolveNamespace($dt, $class->getNamespaceName(), $imports);
+                $types[] = new PropertyType($type, ArrayInformation::notAnArray());
+                continue;
+            }
+
+            $arrayInformation = self::determineArrayInformation($dt);
+
+            $type = NamespaceHelper::resolveNamespace(
+                $dt,
+                $class->getNamespaceName(),
+                $imports
+            );
+
+            $types[] = new PropertyType($type, $arrayInformation);
+        }
+
+        return $types;
+    }
+
+    private static function isArrayType(string $type): bool
+    {
+        return \substr($type, -2) === '[]'
+            || \strpos($type, 'list<') === 0
+            || \strpos($type, 'array<') === 0;
+    }
+
+    private static function determineArrayInformation(string &$type): ArrayInformation
+    {
+        $levels = 0;
+        while (true) {
+            if (substr($type, -2) === '[]') {
+                $levels++;
+                $type = \substr($type, 0, -2);
+
+                continue;
+            }
+
+            if (strpos($type, 'list<') === 0) {
+                $levels++;
+                $type = \substr($type, 5, -1);
+
+                continue;
+            }
+
+            if (strpos($type, 'array<') === 0) {
+                $levels++;
+                $offset = 6;
+                $commaPosition = strpos($type, ',');
+                if (is_int($commaPosition)) {
+                    $offset = $commaPosition + 1;
+                }
+                $type = \trim(\substr($type, $offset, -1));
+
+                continue;
+            }
+
+            break;
+        }
+
+        return $levels === 0 ? ArrayInformation::notAnArray() : ArrayInformation::multiDimension($levels);
     }
 }

--- a/src/JsonMapper.php
+++ b/src/JsonMapper.php
@@ -216,16 +216,7 @@ class JsonMapper implements JsonMapperInterface
     /** @return \stdClass|\stdClass[] */
     private function decodeJsonString(string $json)
     {
-        if (PHP_VERSION_ID >= 70300) {
-            $data = \json_decode($json, false, 512, JSON_THROW_ON_ERROR);
-        } else {
-            $data = \json_decode($json, false);
-            if (\json_last_error() !== JSON_ERROR_NONE) {
-                throw new \JsonException(json_last_error_msg(), \json_last_error());
-            }
-        }
-
-        return $data;
+        return \json_decode($json, false, 512, JSON_THROW_ON_ERROR);
     }
 
     private function resolve(): callable

--- a/src/JsonMapperFactory.php
+++ b/src/JsonMapperFactory.php
@@ -38,10 +38,6 @@ class JsonMapperFactory
 
     public function bestFit(): JsonMapperInterface
     {
-        if (PHP_VERSION_ID <= 70400) {
-            return $this->default();
-        }
-
         $builder = clone ($this->builder);
         return $builder->withDocBlockAnnotationsMiddleware()
             ->withTypedPropertiesMiddleware()

--- a/src/Middleware/Constructor/DefaultFactory.php
+++ b/src/Middleware/Constructor/DefaultFactory.php
@@ -74,7 +74,7 @@ class DefaultFactory
             }
 
             if ($annotationMap->hasParam($param->getName())) {
-                $types = $this->deriveTypesFromDocBlockType($annotationMap->getParam($param->getName()), $reflectedClass, $imports);
+                $types = DocBlockHelper::deriveTypesFromDocBlockType($annotationMap->getParam($param->getName()), $reflectedClass, $imports);
                 $builder->addTypes(...$types);
             }
 
@@ -82,7 +82,7 @@ class DefaultFactory
                 $docComment = $reflectedClass->getProperty($param->getName())->getDocComment();
                 if ($docComment !== false) {
                     $annotationMap = DocBlockHelper::parseDocBlockToAnnotationMap($docComment);
-                    $types = $this->deriveTypesFromDocBlockType($annotationMap->getVar(), $reflectedClass, $imports);
+                    $types = DocBlockHelper::deriveTypesFromDocBlockType($annotationMap->getVar(), $reflectedClass, $imports);
 
                     $builder->addTypes(...$types);
                 }
@@ -123,89 +123,5 @@ class DefaultFactory
             $annotationMap = DocBlockHelper::parseDocBlockToAnnotationMap($docBlock);
         }
         return $annotationMap;
-    }
-
-    /**
-     * @param Import[] $imports
-     * @return PropertyType[]
-     */
-    private function deriveTypesFromDocBlockType(string $docBlockType, \ReflectionClass $class, array $imports): array
-    {
-        $types = [];
-
-        if (strpos($docBlockType, '?') === 0) {
-            $docBlockType = \substr($docBlockType, 1);
-        }
-
-        $docBlockTypes = \explode('|', $docBlockType);
-        $docBlockTypes = \array_filter($docBlockTypes, static function (string $docBlockType) {
-            return $docBlockType !== 'null';
-        });
-
-        foreach ($docBlockTypes as $dt) {
-            $dt = \trim($dt);
-            $isAnArrayType = $this->isArrayType($dt);
-
-            if (! $isAnArrayType) {
-                $type = NamespaceHelper::resolveNamespace($dt, $class->getNamespaceName(), $imports);
-                $types[] = new PropertyType($type, ArrayInformation::notAnArray());
-                continue;
-            }
-
-            $arrayInformation = $this->determineArrayInformation($dt);
-
-            $type = NamespaceHelper::resolveNamespace(
-                $dt,
-                $class->getNamespaceName(),
-                $imports
-            );
-
-            $types[] = new PropertyType($type, $arrayInformation);
-        }
-
-        return $types;
-    }
-
-    private function isArrayType(string $type): bool
-    {
-        return \substr($type, -2) === '[]'
-            || \strpos($type, 'list<') === 0
-            || \strpos($type, 'array<') === 0;
-    }
-
-    private function determineArrayInformation(string &$type): ArrayInformation
-    {
-        $levels = 0;
-        while (true) {
-            if (substr($type, -2) === '[]') {
-                $levels++;
-                $type = \substr($type, 0, -2);
-
-                continue;
-            }
-
-            if (strpos($type, 'list<') === 0) {
-                $levels++;
-                $type = \substr($type, 5, -1);
-
-                continue;
-            }
-
-            if (strpos($type, 'array<') === 0) {
-                $levels++;
-                $offset = 6;
-                $commaPosition = strpos($type, ',');
-                if (is_int($commaPosition)) {
-                    $offset = $commaPosition + 1;
-                }
-                $type = \trim(\substr($type, $offset, -1));
-
-                continue;
-            }
-
-            break;
-        }
-
-        return $levels === 0 ? ArrayInformation::notAnArray() : ArrayInformation::multiDimension($levels);
     }
 }

--- a/src/Middleware/DocBlockAnnotations.php
+++ b/src/Middleware/DocBlockAnnotations.php
@@ -6,6 +6,7 @@ namespace JsonMapper\Middleware;
 
 use JsonMapper\Builders\PropertyBuilder;
 use JsonMapper\Enums\Visibility;
+use JsonMapper\Helpers\DocBlockHelper;
 use JsonMapper\JsonMapperInterface;
 use JsonMapper\ValueObjects\AnnotationMap;
 use JsonMapper\ValueObjects\ArrayInformation;
@@ -53,7 +54,7 @@ class DocBlockAnnotations extends AbstractMiddleware
                 continue;
             }
 
-            $annotations = self::parseDocBlockToAnnotationMap($docBlock);
+            $annotations = DocBlockHelper::parseDocBlockToAnnotationMap($docBlock);
 
             if (! $annotations->hasVar()) {
                 continue;
@@ -97,29 +98,6 @@ class DocBlockAnnotations extends AbstractMiddleware
         $this->cache->set($cacheKey, $intermediatePropertyMap);
 
         return $intermediatePropertyMap;
-    }
-
-    private static function parseDocBlockToAnnotationMap(string $docBlock): AnnotationMap
-    {
-        // Strip away the start "/**' and ending "*/"
-        if (strpos($docBlock, '/**') === 0) {
-            $docBlock = \substr($docBlock, 3);
-        }
-        if (substr($docBlock, -2) === '*/') {
-            $docBlock = \substr($docBlock, 0, -2);
-        }
-        $docBlock = \trim($docBlock);
-
-        $var = null;
-        if (\preg_match_all(self::DOC_BLOCK_REGEX, $docBlock, $matches)) {
-            for ($x = 0, $max = count($matches[0]); $x < $max; $x++) {
-                if ($matches['name'][$x] === 'var') {
-                    $var = $matches['value'][$x];
-                }
-            }
-        }
-
-        return new AnnotationMap($var ?: null, [], null);
     }
 
     /** @return \ReflectionProperty[] */


### PR DESCRIPTION
| Q             | A                                                                                  |
|---------------|------------------------------------------------------------------------------------|
| Branch?       | develop f |
| Bug fix?      | no                                                                             |
| New feature?  | no                                                                             |
| Deprecations? | yes: Drops supports for PHP versions 7.1, 7.2 and 7.3. These will remain stuck on older versions |
| Tickets       | N/A |
| License       | MIT |
| Changelog     | **TODO** |
| Doc PR        | JsonMapper/jsonmapper.github.io#44 |

This PR raises the minimum PHP level in the `composer.json` file and drops the no longer supported version from the GitHub actions workflow.