### PR TITLE
Nullable union property with null value cannot be mapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Nullable union property with null value cannot be mapped [PR#200](https://github.com/JsonMapper/JsonMapper/pull/200)
 
 ## [2.25.0] - 2025-04-29
 ### Fixed

--- a/src/Handler/ValueFactory.php
+++ b/src/Handler/ValueFactory.php
@@ -37,6 +37,10 @@ class ValueFactory
      */
     public function build(JsonMapperInterface $mapper, Property $property, $value)
     {
+        if (\is_null($value) && $property->isNullable()) {
+            return null;
+        }
+
         // For union types, loop through and see if value is a match with the type
         if (\count($property->getPropertyTypes()) > 1) {
             foreach ($property->getPropertyTypes() as $type) {
@@ -94,9 +98,6 @@ class ValueFactory
             }
         }
 
-        if (\is_null($value) && $property->isNullable()) {
-            return null;
-        }
         // No match was found (or there was only one option) lets assume the first is the right one.
         $types = $property->getPropertyTypes();
         $type = \array_shift($types);

--- a/tests/Unit/Handler/ValueFactoryTest.php
+++ b/tests/Unit/Handler/ValueFactoryTest.php
@@ -466,6 +466,25 @@ class ValueFactoryTest extends TestCase
         $this->assertNull($valueFactory->build($jsonMapper, $property, null));
     }
 
+    /**
+     * @covers \JsonMapper\Handler\ValueFactory
+     */
+    public function testItCanMapToNullableClassFromUnionProperty(): void
+    {
+        $property = PropertyBuilder::new()
+            ->setName('value')
+            ->addType(\DateTimeImmutable::class, ArrayInformation::notAnArray())
+            ->addType(\DateTime::class, ArrayInformation::notAnArray())
+            ->setIsNullable(true)
+            ->setVisibility(Visibility::PUBLIC())
+            ->build();
+        $jsonMapper = $this->createMock(JsonMapperInterface::class);
+        $valueFactory = new ValueFactory(new ScalarCaster(), new FactoryRegistry(), new FactoryRegistry());
+
+        $this->assertNull($valueFactory->build($jsonMapper, $property, null));
+    }
+
+
     public function scalarValueDataTypes(): array
     {
         return [


### PR DESCRIPTION
| Q             | A                                                                                  |
|---------------|------------------------------------------------------------------------------------|
| Branch?       | develop  |
| Bug fix?      | yes                                                                            |
| New feature?  | no                                                                             |
| Deprecations? | no                                                                             |
| Tickets       | N/A |
| License       | MIT                                                                                |
| Changelog     | @todo |
| Doc PR        | N/A |

While working with JsonMapper on a project (PHP 8.3 Final read only classes with property promotion) I've found that union properties would end up in the `ValueFactory::mapToSingleObject` where the value of `$json` was `<null>` resulting in type errors. This PR fixes that bug.