### PR TITLE
refactor: Add PHP 8.5 in build matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,6 +64,15 @@ jobs:
             composer_update_flags: '--prefer-lowest --prefer-stable'
             php_ini: 'xdebug.coverage_enable=On'
             name: 'PHP 8.4 with lowest stable deps'
+          - php: 8.5
+            allow_fail: false
+            php_ini: 'xdebug.coverage_enable=On'
+            name: 'PHP 8.5 with latest deps'
+          - php: 8.5
+            allow_fail: false
+            composer_update_flags: '--prefer-lowest --prefer-stable'
+            php_ini: 'xdebug.coverage_enable=On'
+            name: 'PHP 8.5 with lowest stable deps'
 
     runs-on: ubuntu-latest
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
-- Update JetNBrains logo [PR#203](https://github.com/JsonMapper/JsonMapper/pull/203)
+- Update JetBrains logo [PR#203](https://github.com/JsonMapper/JsonMapper/pull/203)
+- Include PHP 8.5 in build matrix [PR#204](https://github.com/JsonMapper/JsonMapper/pull/204)
+
+
 ### Fixed
 - Fix incorrect namespace resolving when using partial use [PR#212](https://github.com/JsonMapper/JsonMapper/pull/212)
 


### PR DESCRIPTION
| Q             | A                                                                                  |
|---------------|------------------------------------------------------------------------------------|
| Branch?       | develop|
| Bug fix?      | 🚫                                                                             |
| New feature?  | 🚫                                                                             |
| Deprecations? | 🚫                                                                             |
| Tickets       | 🚫  |
| License       | MIT                                                                                |
| Changelog     | ✅  |
| Doc PR        | 🚫 |

This PR will:
- Include PHP 8.5 in the build matrix