### PR TITLE
Remove redundant symfony/polyfill-php73 dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update JetBrains logo [PR#203](https://github.com/JsonMapper/JsonMapper/pull/203)
 - Include PHP 8.5 in build matrix [PR#204](https://github.com/JsonMapper/JsonMapper/pull/204)
+- Remove redundant symfony/polyfill-php73 dependency [PR#206](https://github.com/JsonMapper/JsonMapper/pull/206)
 - Raise myclabs/php-enum and phpunit/phpunit version constraints; Drop vimeo/psalm [PR#207](https://github.com/JsonMapper/JsonMapper/pull/207)
+
+### Fixed
+- Fix incorrect namespace resolving when using partial use [PR#212](https://github.com/JsonMapper/JsonMapper/pull/212)
 
 ## [2.25.1] - 2025-05-26
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "phpdocumentor/reflection-docblock": "^5.6",
         "psr/log": "^1.1 || ^2.0 || ^3.0",
         "psr/simple-cache": " ^1.0 || ^2.0 || ^3.0",
-        "symfony/cache": "^4.4 || ^5.0 || ^6.0 || ^7.0",
-        "symfony/polyfill-php73": "^1.18"
+        "symfony/cache": "^4.4 || ^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^6.5 || ^7.0",


### PR DESCRIPTION
This package depends on `symfony/polyfill-php73`, but also `php: ^7.4 || ^8.0`, so the polyfill requirement doesn't seem necessary anymore?