### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,18 @@
+#
+# Exclude these files from release archives, and when running Composer with `--prefer-dist`.
+# https://blog.madewithlove.be/post/gitattributes/
+#
+/.github                 export-ignore
+/tests                   export-ignore
+/.coveralls.yml          export-ignore
+/.gitattributes          export-ignore
+/.gitignore              export-ignore
+/CODE_OF_CONDUCT.md      export-ignore
+/CONTRIBUTING.md         export-ignore
+/SECURITY.md             export-ignore
+/composer.lock           export-ignore
+/phpbench.json           export-ignore
+/phpcs.xml.dist          export-ignore
+/phpstan.neon.dist       export-ignore
+/phpunit.xml.dist        export-ignore
+/psalm.xml               export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update JetBrains logo [PR#203](https://github.com/JsonMapper/JsonMapper/pull/203)
 - Include PHP 8.5 in build matrix [PR#204](https://github.com/JsonMapper/JsonMapper/pull/204)
 - Raise myclabs/php-enum and phpunit/phpunit version constraints; Drop vimeo/psalm [PR#207](https://github.com/JsonMapper/JsonMapper/pull/207)
+- Add `.gitattributes` file to omit development files from releases
 
 ## [2.25.1] - 2025-05-26
 ### Fixed


### PR DESCRIPTION
| Q             | A                                                                                  |
|---------------|------------------------------------------------------------------------------------|
| Branch?       | develop |
| Bug fix?      | no                                                                             |
| New feature?  | no                                                                             |
| Deprecations? | no                                                                             |
| Tickets       | no |
| License       | MIT                                                                                |
| Changelog     | "Add `.gitattributes` file to omit development files from releases" |
| Doc PR        | no |

`composer require json-mapper/json-mapper` results in:

<img width="456" height="484" alt="Screenshot 2026-04-20 at 9 41 03 PM" src="https://github.com/user-attachments/assets/aac86e75-31da-4153-a4b4-4aaf8316d58a" />

This PR adds a `.gitattributes` files to exclude development files.

I ran `ls -a | sed 's/^/\//' >> .gitattributes; sort -u .gitattributes | sponge .gitattributes ` and removed lines that _should_ be included.